### PR TITLE
feat(filter): add meta filter

### DIFF
--- a/alexandria/core/filters.py
+++ b/alexandria/core/filters.py
@@ -1,3 +1,61 @@
-# from django_filters import Filter
+import json
 
-# Add your filters here
+from django.contrib.postgres.fields.jsonb import KeyTextTransform
+from django_filters import Filter, FilterSet
+from django_filters.constants import EMPTY_VALUES
+from rest_framework.exceptions import ValidationError
+
+from alexandria.core import models
+
+
+class JSONValueFilter(Filter):
+    def filter(self, qs, value):
+        if value in EMPTY_VALUES:
+            return qs
+
+        valid_lookups = qs.model._meta.get_field(self.field_name).get_lookups()
+
+        try:
+            value = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            raise ValidationError("JSONValueFilter value needs to be json encoded.")
+
+        for expr in value:
+            if expr in EMPTY_VALUES:  # pragma: no cover
+                continue
+            if not all(("key" in expr, "value" in expr)):
+                raise ValidationError(
+                    'JSONValueFilter value needs to have a "key" and "value" and an '
+                    'optional "lookup" key.'
+                )
+
+            lookup_expr = expr.get("lookup", self.lookup_expr)
+            if lookup_expr not in valid_lookups:
+                raise ValidationError(
+                    f'Lookup expression "{lookup_expr}" not allowed for field '
+                    f'"{self.field_name}". Valid expressions: '
+                    f'{", ".join(valid_lookups.keys())}'
+                )
+            # "contains" behaves differently on JSONFields as it does on TextFields.
+            # That's why we annotate the queryset with the value.
+            # Some discussion about it can be found here:
+            # https://code.djangoproject.com/ticket/26511
+            if isinstance(expr["value"], str):
+                qs = qs.annotate(
+                    field_val=KeyTextTransform(expr["key"], self.field_name)
+                )
+                lookup = {f"field_val__{lookup_expr}": expr["value"]}
+            else:
+                lookup = {
+                    f"{self.field_name}__{expr['key']}__{lookup_expr}": expr["value"]
+                }
+            qs = qs.filter(**lookup)
+        return qs
+
+
+class DocumentFilterSet(FilterSet):
+    meta = JSONValueFilter(field_name="meta")
+
+    class Meta:
+        model = models.Document
+        fields = ["meta"]

--- a/alexandria/core/tests/test_filters.py
+++ b/alexandria/core/tests/test_filters.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+from django.urls import reverse
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.parametrize(
+    "value,status_code",
+    [
+        (json.dumps([{"key": "foo", "value": "bar"}]), HTTP_200_OK),
+        (json.dumps([{"key": "int", "value": 5, "lookup": "gt"}]), HTTP_200_OK),
+        (
+            json.dumps(
+                [{"key": "foo", "value": "bar"}, {"key": "baz", "value": "bla"}]
+            ),
+            HTTP_200_OK,
+        ),
+        (
+            json.dumps([{"key": "foo", "value": "ar", "lookup": "contains"}]),
+            HTTP_200_OK,
+        ),
+        (
+            json.dumps([{"key": "foo", "value": "bar", "lookup": "asdfgh"}]),
+            HTTP_400_BAD_REQUEST,
+        ),
+        (json.dumps([{"key": "foo"}]), HTTP_400_BAD_REQUEST),
+        (json.dumps({"key": "foo"}), HTTP_400_BAD_REQUEST),
+        ("foo", HTTP_400_BAD_REQUEST),
+        ("[{foo, no json)", HTTP_400_BAD_REQUEST),
+    ],
+)
+def test_json_value_filter(db, document_factory, admin_client, value, status_code):
+    doc = document_factory(meta={"foo": "bar", "baz": "bla", "int": 23})
+    document_factory(meta={"foo": "baz"})
+    document_factory()
+    url = reverse("document-list")
+    resp = admin_client.get(url, {"filter[meta]": value})
+    assert resp.status_code == status_code
+    if status_code == HTTP_200_OK:
+        result = resp.json()
+        assert len(result["data"]) == 1
+        assert result["data"][0]["id"] == str(doc.pk)

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -3,6 +3,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework_json_api import views
 
 from . import models, serializers
+from .filters import DocumentFilterSet
 
 
 class CategoryViewSet(views.ModelViewSet):
@@ -18,6 +19,7 @@ class TagViewSet(views.ModelViewSet):
 class DocumentViewSet(views.ModelViewSet):
     serializer_class = serializers.DocumentSerializer
     queryset = models.Document.objects.all()
+    filterset_class = DocumentFilterSet
 
 
 class FileViewSet(


### PR DESCRIPTION
This commit implements a `JSONValueFilter` and adds a FilterSet to the
documents view.

The value for this filter needs to be json encoded als has the following
structure:

```python
[
    {
        "key": "some-key",
        "value": "some value",
        "lookup": "contains",  # optional, defaults to "exact"
    },
    ...
]
```

Multiple lookups are ANDed.