### PR TITLE
feat(tags): add category filter

### DIFF
--- a/alexandria/core/filters.py
+++ b/alexandria/core/filters.py
@@ -1,7 +1,7 @@
 import json
 
 from django.contrib.postgres.fields.jsonb import KeyTextTransform
-from django_filters import Filter, FilterSet
+from django_filters import CharFilter, Filter, FilterSet
 from django_filters.constants import EMPTY_VALUES
 from rest_framework.exceptions import ValidationError
 
@@ -67,3 +67,12 @@ class FileFilterSet(FilterSet):
     class Meta:
         model = models.File
         fields = ["original", "renderings", "type", "meta"]
+
+
+class TagFilterSet(FilterSet):
+    meta = JSONValueFilter(field_name="meta")
+    with_documents_in_category = CharFilter(field_name="documents__category__slug")
+
+    class Meta:
+        model = models.Tag
+        fields = ["with_documents_in_category", "meta"]

--- a/alexandria/core/tests/test_filters.py
+++ b/alexandria/core/tests/test_filters.py
@@ -78,3 +78,20 @@ def test_document_search_filter(
 
     result = resp.json()
     assert len(result["data"]) == amount
+
+
+def test_tag_category_filter(db, document_factory, tag_factory, admin_client):
+    blue = tag_factory(slug="blue")
+    red = tag_factory(slug="red")
+    tag_factory(slug="green")
+    doc1 = document_factory(category__slug="cat1")
+    doc1.tags.add(blue)
+    doc2 = document_factory(category__slug="cat2")
+    doc2.tags.add(red)
+
+    url = reverse("tag-list")
+    resp = admin_client.get(url, {"filter[with-documents-in-category]": "cat1"})
+    assert resp.status_code == HTTP_200_OK
+    result = resp.json()
+    assert len(result["data"]) == 1
+    assert result["data"][0]["id"] == str(blue.pk)

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -16,7 +16,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework_json_api import views
 
 from . import models, serializers
-from .filters import DocumentFilterSet, FileFilterSet
+from .filters import DocumentFilterSet, FileFilterSet, TagFilterSet
 from .thumbs import create_thumbnail
 
 
@@ -46,6 +46,7 @@ class CategoryViewSet(
 class TagViewSet(PermissionViewMixin, VisibilityViewMixin, views.ModelViewSet):
     serializer_class = serializers.TagSerializer
     queryset = models.Tag.objects.all()
+    filterset_class = TagFilterSet
 
 
 class DocumentViewSet(PermissionViewMixin, VisibilityViewMixin, views.ModelViewSet):


### PR DESCRIPTION
This commit adds a filter `category` to the `tag` view. This filter
makes sure, only tags are returned, that actually have at least one
document in the provided category.

Closes #54