### PR TITLE
Feat: Active Group

### DIFF
--- a/alexandria/core/filters.py
+++ b/alexandria/core/filters.py
@@ -53,8 +53,29 @@ class JSONValueFilter(Filter):
         return qs
 
 
+class ActiveGroupFilter(CharFilter):
+    def filter(self, qs, value):
+        if value in EMPTY_VALUES:
+            return qs
+        if value not in self.parent.request.user.groups:
+            raise ValidationError(
+                f"Active group '{value}' is not part of user's assigned groups"
+            )
+        return qs
+
+
+class CategoryFilterSet(FilterSet):
+    meta = JSONValueFilter(field_name="meta")
+    active_group = ActiveGroupFilter()
+
+    class Meta:
+        model = models.Category
+        fields = ["active_group", "meta"]
+
+
 class DocumentFilterSet(FilterSet):
     meta = JSONValueFilter(field_name="meta")
+    active_group = ActiveGroupFilter()
 
     class Meta:
         model = models.Document
@@ -63,6 +84,7 @@ class DocumentFilterSet(FilterSet):
 
 class FileFilterSet(FilterSet):
     meta = JSONValueFilter(field_name="meta")
+    active_group = ActiveGroupFilter()
 
     class Meta:
         model = models.File
@@ -71,6 +93,7 @@ class FileFilterSet(FilterSet):
 
 class TagFilterSet(FilterSet):
     meta = JSONValueFilter(field_name="meta")
+    active_group = ActiveGroupFilter()
     with_documents_in_category = CharFilter(field_name="documents__category__slug")
 
     class Meta:

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -16,7 +16,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework_json_api import views
 
 from . import models, serializers
-from .filters import DocumentFilterSet, FileFilterSet, TagFilterSet
+from .filters import CategoryFilterSet, DocumentFilterSet, FileFilterSet, TagFilterSet
 from .thumbs import create_thumbnail
 
 
@@ -41,6 +41,7 @@ class CategoryViewSet(
 ):
     serializer_class = serializers.CategorySerializer
     queryset = models.Category.objects.all()
+    filterset_class = CategoryFilterSet
 
 
 class TagViewSet(PermissionViewMixin, VisibilityViewMixin, views.ModelViewSet):


### PR DESCRIPTION
Add a new `activeGroup` filter to tell the backend who the user is currently acting as.
Also allow the frontend to pass in `modifiedByGroup` and `createdByGroup` parameters, and validate those against the user's actual groups