### PR TITLE
feat: with_documents_meta filter for tags

### DIFF
--- a/alexandria/core/filters.py
+++ b/alexandria/core/filters.py
@@ -107,8 +107,15 @@ class TagFilterSet(FilterSet):
     meta = JSONValueFilter(field_name="meta")
     active_group = ActiveGroupFilter()
     with_documents_in_category = CharFilter(field_name="documents__category__slug")
+    with_documents_meta = JSONValueFilter(field_name="documents__meta")
     name = CharFilter(lookup_expr="istartswith")
 
     class Meta:
         model = models.Tag
-        fields = ["with_documents_in_category", "meta"]
+        fields = [
+            "meta",
+            "active_group",
+            "with_documents_in_category",
+            "with_documents_meta",
+            "name",
+        ]


### PR DESCRIPTION
This allows limiting display of tags to only those that are
attached to documents with a specific meta value.

For example, when used with Caluma, you could put a caluma
case ID in the document's meta field, and then get only the
tags that are used within the context of a given case.