### PR TITLE
feat(dev): fake auth backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ A list of configuration options which you need
 * Authorization configurations
   * `VISIBILITY_CLASSES`: Comma-separated list of classes that define visibility for all models
   * `PERMISSION_CLASSES` Comma-separated list of classes that define permissions for all models
+
+For development, you can also set the following environemnt variables to help
+you:
+
+  * `DEV_AUTH_BACKEND`: Set this to "true" to enable a fake auth backend that simulates an authenticated user. Requires `DEBUG` to be set to `True` as well.
+  * `DEBUG`: Set this to true for debugging during development. Never enable this in production, as it **will** leak information to the public if you do.
+
 ## Contributing
 
 Look at our [contributing guidelines](CONTRIBUTING.md) to start with your first contribution.

--- a/alexandria/settings.py
+++ b/alexandria/settings.py
@@ -114,10 +114,13 @@ OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
 OIDC_OP_INTROSPECT_ENDPOINT = env.str("OIDC_OP_INTROSPECT_ENDPOINT", default=None)
 OIDC_RP_CLIENT_ID = env.str("OIDC_RP_CLIENT_ID", default=None)
 OIDC_RP_CLIENT_SECRET = env.str("OIDC_RP_CLIENT_SECRET", default=None)
-OIDC_DRF_AUTH_BACKEND = (
-    "alexandria.oidc_auth.authentication.AlexandriaAuthenticationBackend"
-)
 
+DEV_AUTH_BACKEND = env.bool("DEV_AUTH_BACKEND", default=False)
+OIDC_DRF_AUTH_BACKEND = (
+    "alexandria.oidc_auth.authentication.DevelopmentAutnenticationBackend"
+    if DEV_AUTH_BACKEND
+    else "alexandria.oidc_auth.authentication.AlexandriaAuthenticationBackend"
+)
 
 # Extensions
 


### PR DESCRIPTION
Introduce a fake auth backend that can be used mainly for frontend
development, without the need of setting up a full auth infrastructure.

You can set the following env variables to enable it:
```
DEV_AUTH_BACKEND=true
DEBUG=true
```

Note that `DEBUG=true` is explicitly required, so the fake auth backend
doesn't accidentally leak into production.