### PR TITLE
Fix tag filter

### DIFF
--- a/alexandria/core/filters.py
+++ b/alexandria/core/filters.py
@@ -20,6 +20,10 @@ class JSONValueFilter(Filter):
         except json.decoder.JSONDecodeError:
             raise ValidationError("JSONValueFilter value needs to be json encoded.")
 
+        if isinstance(value, dict):
+            # be a bit more tolerant
+            value = [value]
+
         for expr in value:
             if expr in EMPTY_VALUES:  # pragma: no cover
                 continue


### PR DESCRIPTION
The JSONValueFilter gets the possible `meta` lookups from the referenced field, but in a way that didn't work when the referenced field was accessed indirectly (ie. not a field on the current model).
