### PR TITLE
feat: custom validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ A list of configuration options which you need
   * `OIDC_VERIFY_SSL`: Set to `false` if you want to disable verifying SSL certs. Useful for development
 * Authorization configurations
   * `VISIBILITY_CLASSES`: Comma-separated list of classes that define visibility for all models
-  * `PERMISSION_CLASSES` Comma-separated list of classes that define permissions for all models
+  * `PERMISSION_CLASSES`: Comma-separated list of classes that define permissions for all models
+* Data validation configuration
+  * `VALIDATION_CLASSES`: Comma-separated list of classes that define [custom validations](docs/validation.md)
 
 For development, you can also set the following environemnt variables to help
 you:

--- a/alexandria/conftest.py
+++ b/alexandria/conftest.py
@@ -13,6 +13,7 @@ from rest_framework.test import APIClient
 from urllib3 import HTTPResponse
 
 from alexandria.core.models import VisibilityMixin
+from alexandria.core.serializers import BaseSerializer
 from alexandria.core.tests import file_data
 from alexandria.oidc_auth.models import OIDCUser
 
@@ -69,6 +70,13 @@ def reset_visibilities():
     before = VisibilityMixin.visibility_classes
     yield
     VisibilityMixin.visibility_classes = before
+
+
+@pytest.fixture
+def reset_validators():
+    before = BaseSerializer.validation_classes
+    yield
+    BaseSerializer.validation_classes = before
 
 
 @pytest.fixture

--- a/alexandria/core/apps.py
+++ b/alexandria/core/apps.py
@@ -11,10 +11,15 @@ class DefaultConfig(AppConfig):
         # to avoid recursive import error, load extension classes
         # only once the app is ready
         from .models import VisibilityMixin, PermissionMixin
+        from .serializers import BaseSerializer
 
         PermissionMixin.permission_classes = [
             import_string(cls) for cls in settings.PERMISSION_CLASSES
         ]
         VisibilityMixin.visibility_classes = [
             import_string(cls) for cls in settings.VISIBILITY_CLASSES
+        ]
+
+        BaseSerializer.validation_classes = [
+            import_string(cls) for cls in settings.VALIDATION_CLASSES
         ]

--- a/alexandria/core/serializers.py
+++ b/alexandria/core/serializers.py
@@ -10,6 +10,20 @@ from . import models
 class BaseSerializer(serializers.ModelSerializer):
     created_at = serializers.DateTimeField(read_only=True)
 
+    validation_classes = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._custom_validators = []
+
+        validators = [cls(self) for cls in self.validation_classes]
+        for validator in validators:
+            for method_name in [m for m in dir(validator) if not m.startswith("_")]:
+                method = getattr(validator, method_name)
+                if getattr(method, "_validate_model", None) == self.Meta.model:
+                    self._custom_validators.append(method)
+
     def is_valid(self, *args, **kwargs):
         # Prime data so the validators are called (and default values filled
         # if client didn't pass them.)
@@ -19,6 +33,9 @@ class BaseSerializer(serializers.ModelSerializer):
 
     def validate(self, *args, **kwargs):
         validated_data = super().validate(*args, **kwargs)
+
+        for func in self._custom_validators:
+            validated_data = func(validated_data)
 
         user = self.context["request"].user
         validated_data["created_by_user"] = user.username

--- a/alexandria/core/tests/test_validation.py
+++ b/alexandria/core/tests/test_validation.py
@@ -1,0 +1,53 @@
+from collections import Counter
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.urls import reverse
+
+from alexandria.core.models import Document, File
+from alexandria.core.serializers import BaseSerializer
+from alexandria.core.validation import BaseValidator, validator_for
+
+
+def test_validation(db, reset_validators, document, file, admin_client):
+    call_counter = Counter()
+
+    class TestValidator(BaseValidator):
+        @validator_for(Document)
+        def validate(self, data):
+            data["created_by_group"] = "foobar"
+            call_counter["validate"] += 1
+            # Ensure serializer is available and functional
+            assert self.serializer
+            assert self.serializer.context["request"].method == "PATCH"
+            return data
+
+    BaseSerializer.validation_classes = [TestValidator]
+
+    url = reverse("document-detail", args=[document.pk])
+
+    # first, ensure validator is called for Document
+    admin_client.patch(url, json={})
+    assert call_counter["validate"] == 1
+
+    # See if the validation had some effect
+    document.refresh_from_db()
+    assert document.created_by_group == "foobar"
+
+    # second, ensure validator is not called for File
+    url = reverse("file-detail", args=[file.pk])
+    admin_client.patch(url, json={})
+    assert call_counter["validate"] == 1
+
+
+def test_validation_config_error(reset_validators):
+    # We cannot have the same validator method for two models
+    # (no chaining!)
+    with pytest.raises(ImproperlyConfigured):
+
+        class TestValidator(BaseValidator):
+            @validator_for(Document)
+            @validator_for(File)
+            def validate(self, data):
+                # needed for the decorator, but won't ever be called
+                pass  # pragma: no cover

--- a/alexandria/core/validation.py
+++ b/alexandria/core/validation.py
@@ -1,0 +1,51 @@
+import weakref
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+def validator_for(model_cls):
+    def decorator(func):
+        if hasattr(func, "_validate_model"):
+            raise ImproperlyConfigured(
+                f"Method {func.__name__} is already registered to validate {model_cls.__name__}"
+            )
+        func._validate_model = model_cls
+        return func
+
+    return decorator
+
+
+class BaseValidator:
+    """Validate incoming data.
+
+    The validation methods you define here are called at the `validate()` stage
+    of the Rest Framework serializer. You can register any method function in your
+    validator. Methods starting with underscore `_` will be ignored.
+
+    The validation methods will receive a dict with the incoming data,
+    and are expected to return said data. If the data is deemed invalid,
+    the method should raise a `ValidationError`.
+
+    Your validator class must inherit from `BaseValidator`. This enables you to
+    access the serializer via `self.serializer`, allowing you to look at the request
+    object itself, for example.
+
+    Here's a fully functional example:
+
+    ```python
+    class MyCustomFileValidator(BaseValidator):
+        @validate_for(models.File)
+        def validate_file(self, data):
+            # do some checks
+            return data
+    ```
+
+    Note that you must not call `self.serializer.is_valid()` or `self.serializer.validate()`
+    from these classes - this will return in an infinite loop.
+    """
+
+    def __init__(self, serializer):
+        # Weakref to serializer, because we'll have a reference circle
+        # otherwise (serializer -> validator -> serializer...), preventing
+        # garbage collection
+        self.serializer = weakref.proxy(serializer)

--- a/alexandria/settings.py
+++ b/alexandria/settings.py
@@ -131,6 +131,7 @@ VISIBILITY_CLASSES = env.list(
 PERMISSION_CLASSES = env.list(
     "PERMISSION_CLASSES", default=default(["alexandria.core.permissions.AllowAny"])
 )
+VALIDATION_CLASSES = env.list("VALIDATION_CLASSES", default=[])
 
 
 # Storage

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,38 @@
+# Custom validation
+
+Alexandria allows you to define custom validations. To use this, create a new
+file, ensure it's mounted into the container, and set the env variable `VALIDATION_CLASSES`
+to the classes you want to load.
+
+A validation class can then define methods that are called to validate incoming
+data. The calling convention is  similar to those of the Django Rest Framework
+serializers: The incoming data is passed as a dict, which may be inspected and
+modified. The validated data is then returned for further processing.
+If the data is deemed invalid, the method shouldd raise a `ValidationError`.
+
+You can also access the serializer, the context (including the raw request) via
+`self.serializer`.
+
+To implement a custom validator, you need to create a class, inherit from `BaseValidator`,
+then define some validation methods within it. The validation methods need to be
+decorated using `@validator_for(model_class_name)`.
+
+Here's a fully functional example:
+
+```python
+from alexandria.core.validation import BaseValidator, validator_for
+from alexandria.core import models
+
+class MyCustomFileValidator(BaseValidator):
+    @validator_for(models.File)
+    def validate(self, data):
+        # do some checks
+        return data
+```
+
+Note that you must not call `self.serializer.is_valid()` or `self.serializer.validate()`
+from these classes - this will return in an infinite loop.
+
+Validators may be stacked! Which means you can define multiple validators
+for the same model, and they will be called one after the other. However,
+the same validator method may not be used for multiple models.


### PR DESCRIPTION
Introduce custom validation layer, similar to the already-existing
permission and visibility classes.

This allows implementors to define additional validations and extend Alexandria.
Usesful for example when incoming data needs to be checked for additional criteria.