### PR TITLE
fix(ci): use correct claims for username

### DIFF
--- a/alexandria/conftest.py
+++ b/alexandria/conftest.py
@@ -37,13 +37,20 @@ def admin_groups():
 
 @pytest.fixture
 def user(settings, admin_groups):
-    return OIDCUser("sometoken", {"sub": "user", settings.OIDC_GROUPS_CLAIM: ["group"]})
+    return OIDCUser(
+        "sometoken",
+        {settings.OIDC_USERNAME_CLAIM: "user", settings.OIDC_GROUPS_CLAIM: ["group"]},
+    )
 
 
 @pytest.fixture
 def admin_user(settings, admin_groups):
     return OIDCUser(
-        "sometoken", {"sub": "admin", settings.OIDC_GROUPS_CLAIM: admin_groups}
+        "sometoken",
+        {
+            settings.OIDC_USERNAME_CLAIM: "admin",
+            settings.OIDC_GROUPS_CLAIM: admin_groups,
+        },
     )
 
 


### PR DESCRIPTION
Username claim shouldn't be hardcoded - if it's different than "sub" in
an implemented project, the fixtures won't work