### PR TITLE
fix: extend uwsgi buffer

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -5,3 +5,4 @@ max-requests = 2000
 harakiri = 30
 processes = 8
 master = True
+buffer-size = 16384


### PR DESCRIPTION
UWSGI has a buffer of 4096 bytes by default, in which all request headers
must fit. If a user has particularly many roles/groups in their JWT token,
this limit is exceeded. UWSGI will then abort the request, and the reverse
proxy in front will respond with an error such as HTTP/502.