### PR TITLE
fix: add the document_meta filter

### DIFF
--- a/alexandria/core/filters.py
+++ b/alexandria/core/filters.py
@@ -111,6 +111,7 @@ class DocumentFilterSet(FilterSet):
 
 class FileFilterSet(FilterSet):
     meta = JSONValueFilter(field_name="meta")
+    document_meta = JSONValueFilter(field_name="document__meta")
     active_group = ActiveGroupFilter()
     files = BaseCSVFilter(field_name="pk", lookup_expr="in")
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,6 +22,8 @@ services:
     environment:
       - ENV=dev
       - DEBUG=true
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=minio123
       - DEV_AUTH_BACKEND=true
       - ALLOW_ANONYMOUS_WRITE=true
   minio:


### PR DESCRIPTION
Since files don't have the `case-id` on their meta, depending on the way that alexandria is being served, we might have to pass `filter[document-meta]` to the zip route which is implemented in this PR.

I also added two missing minio config vars in the `docker-compose.override.yml` which mean that this can actually be tested when running the `ember-alexandria` frontend (given that `minio` is routed to localhost).