### PR TITLE
feat(dev): make a userspace mountable virtualenv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ docker-compose.*
 Dockerfile
 .dockerignore
 .env
+.venv
 .git
 *.pyc
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.home/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -70,3 +71,7 @@ target/
 
 # Editor swap files
 *.swp
+
+
+# IDE and virtualenv sharing
+.home/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN pip install -U poetry
 
 ARG INSTALL_DEV_DEPENDENCIES=false
 COPY pyproject.toml poetry.lock $APP_HOME/
+ENV VIRTUAL_ENV="$HOME/.cache/pypoetry/virtualenvs/venv"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH" 
+RUN python -m venv $VIRTUAL_ENV
+RUN poetry install
 RUN if [ "$INSTALL_DEV_DEPENDENCIES" = "true" ]; then poetry install; else poetry install --without dev; fi
 
 USER alexandria

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,9 @@ load_example_data: ## Load a set of example data
 .PHONY: flush
 flush: ## Flush the database
 	@docker-compose exec alexandria poetry run python ./manage.py flush --no-input
+
+.PHONE: init-dev-env
+init-dev-env: ## Reinstall poetry after build and set premissions right
+	@docker compose run --rm alexandria poetry install
+	@sudo chown -R "${UID}:${GID}" .
+	@if [ ! -L .venv ]; then ln -s .home/.cache/pypoetry/virtualenvs/venv .venv; fi

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,6 +12,7 @@ services:
         INSTALL_DEV_DEPENDENCIES: "true"
     user: "${UID:?Set UID env variable to your user id}"
     volumes:
+      - home:/home/alexandria
       - ./:/app
     command:
       [
@@ -19,6 +20,8 @@ services:
         "-c",
         "wait-for-it db:5432 -- poetry run python ./manage.py migrate && poetry run python ./manage.py runserver_plus --nostatic 0.0.0.0:8000",
       ]
+    tty: true
+    stdin_open: true
     environment:
       - ENV=dev
       - DEBUG=true
@@ -27,6 +30,8 @@ services:
       - ALEXANDRIA_DEV_AUTH_BACKEND=true
       - ALEXANDRIA_ALLOW_ANONYMOUS_WRITE=true
   minio:
+    ports:
+      - "9000:9000"
     environment:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123
@@ -36,3 +41,12 @@ services:
     environment:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123
+
+volumes:
+  home:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: .home
+  uploads:


### PR DESCRIPTION
The `.home` directory holds the in-container virtualenv that can be made `rw` and hence edited for debugging purposes.

You can e. g. `ln -s` to the venv location for a shortcut when you need to edit files or set breakpoints etc. E. g. `.venv`

The same way the virtualenv is available for the languageserver (e. g. pyright) for code inspection, navigate the source, auto-importing etc. so you will not need to maintain an extra virtualenv on the host.