### PR TITLE
feat(storage): don't use django default storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A list of configuration options which you need
 
   Storage backends are configured globally. The storable object bears information on the encryption status allowing the ORM appropriate handling of the data.
 
-  - `FILE_STORAGE_BACKEND`: Set the backend for file uploads. `django-storages` is available (default: `django.core.files.storage.FileSystemStorage`)
+  - `ALEXANDRIA_FILE_STORAGE`: Set the backend for file uploads. `django-storages` is available (default: `alexandria.storages.backends.s3.S3Storage`)
 
   Encryption:
 
@@ -94,7 +94,7 @@ A list of configuration options which you need
   - `ALEXANDRIA_ENCRYPTION_METHOD`: Define encryption method that is applied to uploaded objects. Available values depend on storage backend's capabilities (default: `None`)
     - available methods
       - None: no at-rest encryption
-      - `ssec-global`: encrypt all files with the same key (requires: `FILE_STORAGE_BACKEND`: `alexandria.storages.s3.S3Storage)
+      - `ssec-global`: encrypt all files with the same key (requires: `ALEXANDRIA_FILE_STORAGE`: `alexandria.storages.backends.s3.S3Storage`)
 
   Supported backends:
 
@@ -103,13 +103,13 @@ A list of configuration options which you need
 
     required configuations:
 
-    - `AWS_S3_ACCESS_KEY_ID`: identity
-    - `AWS_S3_SECRET_ACCESS_KEY`: password to authorize identity
-    - `AWS_S3_ENDPOINT_URL`: the url of the service
-    - `AWS_STORAGE_BUCKET_NAME`: the bucket name of the storage to access objects in path notation (not subdomain)
+    - `ALEXANDRIA_S3_ACCESS_KEY`: identity
+    - `ALEXANDRIA_S3_SECRET_KEY`: password to authorize identity
+    - `ALEXANDRIA_S3_ENDPOINT_URL`: the url of the service
+    - `ALEXANDRIA_S3_BUCKET_NAME`: the bucket name of the storage to access objects in path notation (not subdomain)
 
     The development setup features a minio service, implementing the S3 protocol.
-    To use SSE-C in development make sure to generate a certificate for the minio container and set `AWS_S3_VERIFY` to `false`.
+    To use SSE-C in development make sure to generate a certificate for the minio container and set `ALEXANDRIA_S3_VERIFY` to `false`.
 
 For development, you can also set the following environemnt variables to help you:
 

--- a/alexandria/conftest.py
+++ b/alexandria/conftest.py
@@ -31,7 +31,7 @@ register_module(importlib.import_module(".core.factories", "alexandria"))
 
 @pytest.fixture(autouse=True)
 def _default_file_storage_backend(settings):
-    settings.DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+    settings.ALEXANDRIA_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = False
 
 

--- a/alexandria/core/management/commands/encrypt_files.py
+++ b/alexandria/core/management/commands/encrypt_files.py
@@ -9,7 +9,7 @@ from alexandria.storages.backends.s3 import SsecGlobalS3Storage
 
 # This is needed to disable the warning about not verifying the SSL certificate.
 # It spams the output otherwise.
-if not settings.AWS_S3_VERIFY:
+if not settings.ALEXANDRIA_S3_VERIFY:
     import urllib3
 
     urllib3.disable_warnings()
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         missing_files = []
 
         # flip between default and encrypted storage to have the correct parameters in the requests
-        DefaultStorage = get_storage_class()
+        Storage = get_storage_class(settings.ALEXANDRIA_FILE_STORAGE)
         for file in tqdm(
             File.objects.filter(
                 Q(encryption_status=File.EncryptionStatus.NOT_ENCRYPTED)
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             ),
         ):
             # get original file content
-            file.content.storage = DefaultStorage()
+            file.content.storage = Storage()
             try:
                 content = file.content.open()
             except FileNotFoundError:  # pragma: no cover

--- a/alexandria/core/tests/test_commands.py
+++ b/alexandria/core/tests/test_commands.py
@@ -15,7 +15,7 @@ def test_encrypt_files(db, settings, mocker, file_factory):
 
     settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = True
     settings.ALEXANDRIA_ENCRYPTION_METHOD = File.EncryptionStatus.SSEC_GLOBAL_KEY.value
-    settings.DEFAULT_FILE_STORAGE = "alexandria.storages.backends.s3.S3Storage"
+    settings.ALEXANDRIA_FILE_STORAGE = "alexandria.storages.backends.s3.S3Storage"
 
     mocker.patch("storages.backends.s3.S3Storage.save")
     mocker.patch("storages.backends.s3.S3Storage.open")

--- a/alexandria/core/tests/test_views.py
+++ b/alexandria/core/tests/test_views.py
@@ -172,7 +172,7 @@ def test_at_rest_encryption(admin_client, settings, document, mocker):
     settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = True
     settings.ALEXANDRIA_ENABLE_THUMBNAIL_GENERATION = False
     settings.ALEXANDRIA_ENCRYPTION_METHOD = File.EncryptionStatus.SSEC_GLOBAL_KEY
-    settings.DEFAULT_FILE_STORAGE = "storages.backends.s3.S3Storage"
+    settings.ALEXANDRIA_FILE_STORAGE = "storages.backends.s3.S3Storage"
     data = {
         "name": "file.png",
         "document": str(document.pk),

--- a/alexandria/settings/alexandria.py
+++ b/alexandria/settings/alexandria.py
@@ -81,8 +81,8 @@ GENERIC_PERMISSIONS_VALIDATION_CLASSES = ALEXANDRIA_VALIDATION_CLASSES
 #
 # The default storage is the file system. This is mostly for development and
 # testing environments.
-DEFAULT_FILE_STORAGE = env.str(
-    "DEFAULT_FILE_STORAGE", default="alexandria.storages.backends.s3.S3Storage"
+ALEXANDRIA_FILE_STORAGE = env.str(
+    "ALEXANDRIA_FILE_STORAGE", default="alexandria.storages.backends.s3.S3Storage"
 )
 ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = env.bool(
     "ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION", default=False
@@ -107,7 +107,7 @@ ALEXANDRIA_DOWNLOAD_URL_LIFETIME = env.int(
 #
 # S3 compatible services like Amazon S3, Minio or Exoscale
 #
-# In order to make use an S3 storage backe set `FILE_STORAGE_BACKEND` to one of
+# In order to make use an S3 storage backend set `ALEXANDRIA_FILE_STORAGE` to one of
 #  - storages.backends.s3.S3Storage
 #  - storages.backends.s3boto3.S3Boto3Storage
 # For your convenience alexandria provides:
@@ -129,21 +129,25 @@ ALEXANDRIA_DOWNLOAD_URL_LIFETIME = env.int(
 #                a unique object specific property.
 #
 # Identity to access the storage service
-AWS_S3_ACCESS_KEY_ID = env.str("AWS_S3_ACCESS_KEY_ID", default="minio")
+ALEXANDRIA_S3_ACCESS_KEY = env.str("ALEXANDRIA_S3_ACCESS_KEY", default="minio")
 # SECRET to authenticate with the storage service
-AWS_S3_SECRET_ACCESS_KEY = env.str("AWS_S3_SECRET_ACCESS_KEY", default="minio123")
-AWS_S3_ENDPOINT_URL = env.str("AWS_S3_ENDPOINT_URL", default="http://minio:9000")
+ALEXANDRIA_S3_SECRET_KEY = env.str("ALEXANDRIA_S3_SECRET_KEY", default="minio123")
+ALEXANDRIA_S3_ENDPOINT_URL = env.str(
+    "ALEXANDRIA_S3_ENDPOINT_URL", default="http://minio:9000"
+)
 # SSL is turned off for the dev environment. Don't do that in production
-AWS_S3_USE_SSL = env.bool("AWS_S3_USE_SSL", default=False)
+ALEXANDRIA_S3_USE_SSL = env.bool("ALEXANDRIA_S3_USE_SSL", default=False)
 # SSL certificate verification is turned off for the dev environment. Don't do that in production
-AWS_S3_VERIFY = env.bool("AWS_S3_VERIFY", default=False)
-AWS_STORAGE_BUCKET_NAME = env.str("AWS_STORAGE_BUCKET_NAME", default="alexandria-media")
+ALEXANDRIA_S3_VERIFY = env.bool("ALEXANDRIA_S3_VERIFY", default=False)
+ALEXANDRIA_S3_BUCKET_NAME = env.str(
+    "ALEXANDRIA_S3_BUCKET_NAME", default="alexandria-media"
+)
 # Object parameter translate to specific headers and values in put and get requests
-AWS_S3_OBJECT_PARAMETERS = {}
+ALEXANDRIA_S3_OBJECT_PARAMETERS = {}
 # Shared secret for at-rest encryption of objects
 # NOTE: required to be 32 bytes long
-AWS_S3_STORAGE_SSEC_SECRET = env.str(
-    "AWS_S3_STORAGE_SSEC_SECRET", default="".join(["x" for _ in range(32)])
+ALEXANDRIA_S3_STORAGE_SSEC_SECRET = env.str(
+    "ALEXANDRIA_S3_STORAGE_SSEC_SECRET", default="".join(["x" for _ in range(32)])
 )
 
 # Thumbnails

--- a/alexandria/storages/backends/s3.py
+++ b/alexandria/storages/backends/s3.py
@@ -1,13 +1,30 @@
 from django.conf import ImproperlyConfigured, settings as django_settings
-from storages.backends.s3 import S3Storage
+from storages.backends.s3 import S3Storage as OriginalS3Storage
+from storages.utils import setting
+
+
+class S3Storage(OriginalS3Storage):
+    def get_default_settings(self):
+        return {
+            **super().get_default_settings(),
+            # required settings
+            "access_key": setting("ALEXANDRIA_S3_ACCESS_KEY"),
+            "secret_key": setting("ALEXANDRIA_S3_SECRET_KEY"),
+            "endpoint_url": setting("ALEXANDRIA_S3_ENDPOINT_URL"),
+            "bucket_name": setting("ALEXANDRIA_S3_BUCKET_NAME"),
+            # optional settings
+            "use_ssl": setting("ALEXANDRIA_S3_USE_SSL"),
+            "verify": setting("ALEXANDRIA_S3_VERIFY"),
+            "object_parameters": setting("ALEXANDRIA_S3_OBJECT_PARAMETERS", {}),
+        }
 
 
 class SsecGlobalS3Storage(S3Storage):
     def __init__(self, **settings):
         super().__init__(**settings)
-        self.ssec_secret = django_settings.AWS_S3_STORAGE_SSEC_SECRET
+        self.ssec_secret = django_settings.ALEXANDRIA_S3_STORAGE_SSEC_SECRET
         if len(key := self.ssec_secret) != 32:
-            msg = f"AWS_S3_STORAGE_SSEC_SECRET keylength is: {len(key)}, expected length is 32"
+            msg = f"ALEXANDRIA_S3_STORAGE_SSEC_SECRET keylength is: {len(key)}, expected length is 32"
             raise ImproperlyConfigured(msg)
 
     def get_object_parameters(self, name):  # pragma: no cover, TODO: cover

--- a/alexandria/storages/fields.py
+++ b/alexandria/storages/fields.py
@@ -10,8 +10,7 @@ from alexandria.storages.backends.s3 import SsecGlobalS3Storage
 class DynamicStorageFieldFile(FieldFile):
     def __init__(self, instance, field, name):
         super().__init__(instance, field, name)
-        DefaultStorage = get_storage_class()
-        self.storage = DefaultStorage()
+        self.storage = get_storage_class(settings.ALEXANDRIA_FILE_STORAGE)()
         if settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION:
             from alexandria.core.models import File
 
@@ -24,8 +23,7 @@ class DynamicStorageFileField(models.FileField):
 
     def pre_save(self, instance, add):
         # set storage to default storage class to prevent reusing the last selection
-        DefaultStorage = get_storage_class()
-        self.storage = DefaultStorage()
+        self.storage = get_storage_class(settings.ALEXANDRIA_FILE_STORAGE)()
         if settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION:
             from alexandria.core.models import File
 
@@ -43,7 +41,7 @@ class DynamicStorageFileField(models.FileField):
             if not isinstance(self.storage, S3Storage):
                 msg = (
                     "At-rest object encryption is currently only available for S3 compatible storage backends. "
-                    "Set `DEFAULT_FILE_STORAGE` to `alexandria.storages.s3.S3Storage`."
+                    "Set `ALEXANDRIA_FILE_STORAGE` to `alexandria.storages.s3.S3Storage`."
                 )
                 raise ImproperlyConfigured(msg)
             storage = SsecGlobalS3Storage()

--- a/alexandria/storages/tests/test_dynamic_field.py
+++ b/alexandria/storages/tests/test_dynamic_field.py
@@ -14,11 +14,11 @@ def test_dynamic_storage_select_global_ssec(
     db, settings, file_factory, method, secret, raises, mocker
 ):
     # set s3 compatible storage backend
-    settings.DEFAULT_FILE_STORAGE = "alexandria.storages.backends.s3.S3Storage"
+    settings.ALEXANDRIA_FILE_STORAGE = "alexandria.storages.backends.s3.S3Storage"
     settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = True
 
     settings.ALEXANDRIA_ENCRYPTION_METHOD = method
-    settings.AWS_S3_STORAGE_SSEC_SECRET = secret
+    settings.ALEXANDRIA_S3_STORAGE_SSEC_SECRET = secret
 
     mocker.patch("storages.backends.s3.S3Storage.save")
     SsecGlobalS3Storage.save.return_value = "name-of-the-file"
@@ -49,7 +49,7 @@ def test_dynamic_storage_select_global_ssec(
 )
 def test_backend_configurations(db, settings, file_factory, method, storage_backend):
     settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = True
-    settings.DEFAULT_FILE_STORAGE = storage_backend
+    settings.ALEXANDRIA_FILE_STORAGE = storage_backend
     settings.ALEXANDRIA_ENCRYPTION_METHOD = method
     with pytest.raises(ImproperlyConfigured):
         file_factory()


### PR DESCRIPTION
BREAKING CHANGE: Instead of overwriting `DEFAULT_FILE_STORAGE` in the host app, Alexandria now uses a separate setting `ALEXANDRIA_FILE_STORAGE` to configure the used file storage backend.