### PR TITLE
chore(release): 3.0.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0-beta.11
+### Feature
+* **security:** Add ClamAV integration ([`fe314ca`](https://github.com/projectcaluma/alexandria/commit/fe314ca80433de1c866c40fa8673cbb7eee90a80))
+
 # 3.0.0-beta.10
 ### Feature
 * **file:** Add method to generate a download url for a file ([`d28664e`](https://github.com/projectcaluma/alexandria/commit/d28664e82ed0253ca3cffad6a8d6d53af95e89a2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma-alexandria"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 description = "Document management service"
 repository = "https://github.com/projectcaluma/alexandria"
 authors = ["Caluma <info@caluma.io>"]
@@ -107,7 +107,13 @@ exclude_lines = [
     "def __unicode__",
     "def __repr__",
 ]
-omit = ["*/migrations/*", "*/apps.py", "manage.py", "alexandria/wsgi.py", "generate_missing_thumbnails.py"]
+omit = [
+    "*/migrations/*",
+    "*/apps.py",
+    "manage.py",
+    "alexandria/wsgi.py",
+    "generate_missing_thumbnails.py",
+]
 show_missing = true
 
 [build-system]


### PR DESCRIPTION
* **security:** Add ClamAV integration ([`fe314ca`](https://github.com/projectcaluma/alexandria/commit/fe314ca80433de1c866c40fa8673cbb7eee90a80))