### PR TITLE
Various fixes for the WebDAV-API

### DIFF
--- a/alexandria/core/serializers.py
+++ b/alexandria/core/serializers.py
@@ -182,19 +182,15 @@ class FileSerializer(BaseSerializer):
         request = self.context.get("request")
         scheme = request.scheme if request else "http"
         host = request.get_host() if request else "localhost"
-        username = (
-            default_user_attribute(
-                request.user, settings.ALEXANDRIA_CREATED_BY_USER_PROPERTY
-            )
-            if request is not None
-            else None
+        username = getattr(
+            getattr(request, "user", None),
+            settings.ALEXANDRIA_CREATED_BY_USER_PROPERTY,
+            None,
         )
-        group = (
-            default_user_attribute(
-                request.user, settings.ALEXANDRIA_CREATED_BY_GROUP_PROPERTY
-            )
-            if request is not None
-            else None
+        group = getattr(
+            getattr(request, "user", None),
+            settings.ALEXANDRIA_CREATED_BY_GROUP_PROPERTY,
+            None,
         )
         return instance.get_webdav_url(username, group, scheme, host)
 

--- a/alexandria/core/serializers.py
+++ b/alexandria/core/serializers.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.template.defaultfilters import slugify
 from django.utils import translation
 from django_clamd.validators import validate_file_infection
@@ -14,10 +13,6 @@ from rest_framework_json_api import serializers
 from . import models
 
 
-def default_user_attribute(user, attribute):
-    return getattr(user, attribute) if not isinstance(user, AnonymousUser) else None
-
-
 class BaseSerializer(
     ValidatorMixin, VisibilitySerializerMixin, serializers.ModelSerializer
 ):
@@ -28,11 +23,15 @@ class BaseSerializer(
     def is_valid(self, *args, **kwargs):
         # Prime data so the validators are called (and default values filled
         # if client didn't pass them.)
-        group = default_user_attribute(
-            self.context["request"].user, settings.ALEXANDRIA_CREATED_BY_GROUP_PROPERTY
+        group = getattr(
+            self.context["request"].user,
+            settings.ALEXANDRIA_CREATED_BY_GROUP_PROPERTY,
+            None,
         )
-        user = default_user_attribute(
-            self.context["request"].user, settings.ALEXANDRIA_CREATED_BY_USER_PROPERTY
+        user = getattr(
+            self.context["request"].user,
+            settings.ALEXANDRIA_CREATED_BY_USER_PROPERTY,
+            None,
         )
         self.initial_data.setdefault("created_by_group", group)
         self.initial_data.setdefault("modified_by_group", group)

--- a/alexandria/core/serializers.py
+++ b/alexandria/core/serializers.py
@@ -179,6 +179,8 @@ class FileSerializer(BaseSerializer):
         return instance.get_download_url(self.context.get("request"))
 
     def get_webdav_url(self, instance):
+        if instance.variant != models.File.Variant.ORIGINAL:
+            return None
         request = self.context.get("request")
         scheme = request.scheme if request else "http"
         host = request.get_host() if request else "localhost"

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -129,11 +129,11 @@ class DocumentViewSet(PermissionViewMixin, VisibilityViewMixin, ModelViewSet):
 
         response.raise_for_status()
 
-        username = serializers.default_user_attribute(
-            request.user, settings.ALEXANDRIA_CREATED_BY_USER_PROPERTY
+        username = getattr(
+            request.user, settings.ALEXANDRIA_CREATED_BY_USER_PROPERTY, None
         )
-        group = serializers.default_user_attribute(
-            request.user, settings.ALEXANDRIA_CREATED_BY_GROUP_PROPERTY
+        group = getattr(
+            request.user, settings.ALEXANDRIA_CREATED_BY_GROUP_PROPERTY, None
         )
 
         converted_document = models.Document.objects.create(

--- a/alexandria/dav.py
+++ b/alexandria/dav.py
@@ -94,7 +94,6 @@ class AlexandriaFileResource(ManabiFileResourceMixin, DAVNonCollection):
         return self.memory_file
 
     def end_write(self, *, with_errors):
-        super().end_write(with_errors=with_errors)
         try:
             validate_file_infection(self.memory_file)
         except ValidationError:
@@ -122,6 +121,7 @@ class AlexandriaFileResource(ManabiFileResourceMixin, DAVNonCollection):
         file.save()
         self.file = file
         self.memory_file.do_close()
+        super().end_write(with_errors=with_errors)
 
 
 class AlexandriaProvider(ManabiProvider):

--- a/alexandria/dav.py
+++ b/alexandria/dav.py
@@ -54,7 +54,14 @@ class AlexandriaFileResource(ManabiFileResourceMixin, DAVNonCollection):
         self._cb_config = cb_hook_config
         self._token = environ["manabi.token"]
         self.user, self.group, file_pk = self._token.payload
-        self.file = File.objects.get(pk=file_pk)
+
+        # We only serve the newest original File of the Document.
+        self.file = (
+            File.objects.get(pk=file_pk)
+            .document.files.filter(variant=File.Variant.ORIGINAL)
+            .order_by("-created_at")
+            .first()
+        )
         self.memory_file = MyBytesIO()
         self.name = Path(self.path).name
 


### PR DESCRIPTION
 - fix: only serve newest File form Document
  This is needed for multiple reasons:

   1. There is no need to edit old files and the result would probably be
      unexpected
   2. When creating a new version, Libreoffice doesn't know about this and
      it would use the older File as startingpoint. Leading to a new
      version on every save.
 - fix: only create webDAV links for original Files
 - fix: run hooks after file save was successful
 - chore: simplify fetching user attributes from request