### PR TITLE
chore: add some comments so we don't forget factoring out storage code

### DIFF
--- a/alexandria/core/models.py
+++ b/alexandria/core/models.py
@@ -222,6 +222,10 @@ class File(UUIDModel):
         null=True,
         blank=True,
     )
+
+    # TODO: When next working on file / storage stuff, consider extracting
+    # the storage code into it's own project, so we can reuse it outside
+    # of Alexandria: https://github.com/projectcaluma/alexandria/issues/480
     content = DynamicStorageFileField(upload_to=upload_file_content_to, max_length=300)
     mime_type = models.CharField(max_length=255)
     size = models.IntegerField()

--- a/alexandria/core/serializers.py
+++ b/alexandria/core/serializers.py
@@ -248,6 +248,10 @@ class FileSerializer(BaseSerializer):
             self.initial_data["original"] = {"type": "files", "id": original}
 
     def is_valid(self, *args, raise_exception=False, **kwargs):
+        # TODO: When next working on file / storage stuff, consider extracting
+        # the storage code into it's own project, so we can reuse it outside
+        # of Alexandria: https://github.com/projectcaluma/alexandria/issues/480
+
         if self.context["request"].content_type.startswith("multipart/"):
             self._prepare_multipart()
         return super().is_valid(*args, raise_exception=raise_exception, **kwargs)

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -250,6 +250,10 @@ class FileViewSet(
     def create(self, request, *args, **kwargs):
         # invoke dgap permission check
         self._check_permissions(request)
+
+        # TODO: When next working on file / storage stuff, consider extracting
+        # the storage code into it's own project, so we can reuse it outside
+        # of Alexandria: https://github.com/projectcaluma/alexandria/issues/480
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         if settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION:

--- a/alexandria/storages/fields.py
+++ b/alexandria/storages/fields.py
@@ -21,6 +21,10 @@ class DynamicStorageFieldFile(FieldFile):
 class DynamicStorageFileField(models.FileField):
     attr_class = DynamicStorageFieldFile
 
+    # TODO: When next working on file / storage stuff, consider extracting
+    # the storage code into it's own project, so we can reuse it outside
+    # of Alexandria: https://github.com/projectcaluma/alexandria/issues/480
+
     def pre_save(self, instance, add):
         # set storage to default storage class to prevent reusing the last selection
         self.storage = get_storage_class(settings.ALEXANDRIA_FILE_STORAGE)()


### PR DESCRIPTION
We decided to (soon) factor out the file storage code into it's own
proposed module / package, so it can be reused outside of Alexandria.

To ensure we don't forget it next time we work on this code, we're adding
a few TODO lines in context where it may make sense.

See #480 for details

