### PR TITLE
chore(release): 3.0.0-beta.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0-beta.17
+### Fix
+* **webdav:** Split alexandria provider out of dav.py ([`a0c7d64`](https://github.com/projectcaluma/alexandria/commit/a0c7d64412bc8fada912b94c5206823278a76052))
+
 # 3.0.0-beta.16
 ### Fix
 * **webdav:** Make scheme a setting ([`a634c86`](https://github.com/projectcaluma/alexandria/commit/a634c863c3219ca465c15b40f6e80971b6905b9f))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma-alexandria"
-version = "3.0.0-beta.16"
+version = "3.0.0-beta.17"
 description = "Document management service"
 repository = "https://github.com/projectcaluma/alexandria"
 authors = ["Caluma <info@caluma.io>"]


### PR DESCRIPTION
Fix
* **webdav:** Split alexandria provider out of dav.py ([`a0c7d64`](https://github.com/projectcaluma/alexandria/commit/a0c7d64412bc8fada912b94c5206823278a76052))