### PR TITLE
fix: move file validation to model

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A list of configuration options which you need
   - `ALEXANDRIA_VISIBILITY_CLASSES`: Comma-separated list of [DGAP](https://github.com/adfinis/django-generic-api-permissions/?tab=readme-ov-file#visibilities) classes that define visibility for all models
   - `ALEXANDRIA_PERMISSION_CLASSES`: Comma-separated list of [DGAP](https://github.com/adfinis/django-generic-api-permissions/?tab=readme-ov-file#permissions) classes that define permissions for all models
 - Data validation configuration
-  - `ALEXANDRIA_VALIDATION_CLASSES`: Comma-separated list of [DGAP](https://github.com/adfinis/django-generic-api-permissions/?tab=readme-ov-file#data-validation) classes that define custom validations
+  - `ALEXANDRIA_VALIDATION_CLASSES`: Comma-separated list of [DGAP](https://github.com/adfinis/django-generic-api-permissions/?tab=readme-ov-file#data-validation) classes that define custom validations. A default base class is used for file validation. Extend `AlexandriaValidator` for own validations.
 - Thumbnail configuration (optional)
 
   - `ALEXANDRIA_ENABLE_THUMBNAIL_GENERATION`: Set to `false` to disable thumbnail generation

--- a/alexandria/core/api.py
+++ b/alexandria/core/api.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.files import File
 
 from alexandria.core import models
+from alexandria.core.validations import validate_file
 
 log = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ def create_file(
     Use this instead of the normal File.objects.create to ensure that all important fields are set.
     As well as generating a thumbnail for the file.
     """
-    file = models.File.objects.create(
+    file = models.File(
         name=name,
         content=content,
         mime_type=mime_type,
@@ -82,7 +83,7 @@ def create_file(
         modified_by_group=group,
         **additional_attributes,
     )
-
-    file.create_thumbnail()
+    validate_file(file)
+    file.save()
 
     return file

--- a/alexandria/core/models.py
+++ b/alexandria/core/models.py
@@ -181,8 +181,6 @@ class Document(UUIDModel):
                 latest_original.document = self
                 latest_original.save()
 
-        latest_original.create_thumbnail()
-
         return self
 
 
@@ -241,7 +239,13 @@ class File(UUIDModel):
     ):
         if settings.ALEXANDRIA_ENABLE_CHECKSUM:
             self.set_checksum()
-        return super().save(force_insert, force_update, using, update_fields)
+
+        file = super().save(force_insert, force_update, using, update_fields)
+
+        if self.variant == File.Variant.ORIGINAL and self.renderings.count() == 0:
+            self.create_thumbnail()
+
+        return file
 
     def get_webdav_url(self, username, group, host="localhost:8000"):
         # The path doesn't need to match the actual file path, because we're accessing

--- a/alexandria/core/tests/__snapshots__/test_viewsets.ambr
+++ b/alexandria/core/tests/__snapshots__/test_viewsets.ambr
@@ -5,9 +5,9 @@
       'SELECT "alexandria_core_category"."created_at", "alexandria_core_category"."created_by_user", "alexandria_core_category"."created_by_group", "alexandria_core_category"."modified_at", "alexandria_core_category"."modified_by_user", "alexandria_core_category"."modified_by_group", "alexandria_core_category"."metainfo", "alexandria_core_category"."slug", "alexandria_core_category"."name", "alexandria_core_category"."description", "alexandria_core_category"."allowed_mime_types", "alexandria_core_category"."color", "alexandria_core_category"."parent_id" FROM "alexandria_core_category" WHERE "alexandria_core_category"."slug" = \'note-act-source\' LIMIT 21',
       'INSERT INTO "alexandria_core_document" ("created_at", "created_by_user", "created_by_group", "modified_at", "modified_by_user", "modified_by_group", "metainfo", "id", "title", "description", "category_id", "date") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'{}\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'winstonsmith\',\'\',\'\']), hstore(ARRAY[\'en\',\'de\',\'fr\'], ARRAY[\'\',\'\',\'\']), \'note-act-source\', NULL)',
       'SELECT "alexandria_core_document"."created_at", "alexandria_core_document"."created_by_user", "alexandria_core_document"."created_by_group", "alexandria_core_document"."modified_at", "alexandria_core_document"."modified_by_user", "alexandria_core_document"."modified_by_group", "alexandria_core_document"."metainfo", "alexandria_core_document"."id", "alexandria_core_document"."title", "alexandria_core_document"."description", "alexandria_core_document"."category_id", "alexandria_core_document"."date" FROM "alexandria_core_document" WHERE "alexandria_core_document"."id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid LIMIT 21',
-      'SELECT "alexandria_core_document"."created_at", "alexandria_core_document"."created_by_user", "alexandria_core_document"."created_by_group", "alexandria_core_document"."modified_at", "alexandria_core_document"."modified_by_user", "alexandria_core_document"."modified_by_group", "alexandria_core_document"."metainfo", "alexandria_core_document"."id", "alexandria_core_document"."title", "alexandria_core_document"."description", "alexandria_core_document"."category_id", "alexandria_core_document"."date" FROM "alexandria_core_document" WHERE "alexandria_core_document"."id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid LIMIT 21',
       'SELECT "alexandria_core_category"."created_at", "alexandria_core_category"."created_by_user", "alexandria_core_category"."created_by_group", "alexandria_core_category"."modified_at", "alexandria_core_category"."modified_by_user", "alexandria_core_category"."modified_by_group", "alexandria_core_category"."metainfo", "alexandria_core_category"."slug", "alexandria_core_category"."name", "alexandria_core_category"."description", "alexandria_core_category"."allowed_mime_types", "alexandria_core_category"."color", "alexandria_core_category"."parent_id" FROM "alexandria_core_category" WHERE "alexandria_core_category"."slug" = \'note-act-source\' LIMIT 21',
       'INSERT INTO "alexandria_core_file" ("created_at", "created_by_user", "created_by_group", "modified_at", "modified_by_user", "modified_by_group", "metainfo", "id", "variant", "original_id", "name", "document_id", "checksum", "encryption_status", "content", "mime_type", "size") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'{}\', \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid, \'original\', NULL, \'content\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, \'sha256:a154d301b8eb0a1af4c32bb560689af62fd1afd50221533cb414191babbc9fef\', NULL, \'ea416ed0-759d-46a8-de58-f63a59077499_content\', \'application/octet-stream\', 67)',
+      'SELECT COUNT(*) AS "__count" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid',
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
       'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid',
       'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid',
@@ -96,11 +96,11 @@
   dict({
     'queries': list([
       'SELECT "alexandria_core_document"."created_at", "alexandria_core_document"."created_by_user", "alexandria_core_document"."created_by_group", "alexandria_core_document"."modified_at", "alexandria_core_document"."modified_by_user", "alexandria_core_document"."modified_by_group", "alexandria_core_document"."metainfo", "alexandria_core_document"."id", "alexandria_core_document"."title", "alexandria_core_document"."description", "alexandria_core_document"."category_id", "alexandria_core_document"."date" FROM "alexandria_core_document" WHERE "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid LIMIT 21',
-      'SELECT "alexandria_core_document"."created_at", "alexandria_core_document"."created_by_user", "alexandria_core_document"."created_by_group", "alexandria_core_document"."modified_at", "alexandria_core_document"."modified_by_user", "alexandria_core_document"."modified_by_group", "alexandria_core_document"."metainfo", "alexandria_core_document"."id", "alexandria_core_document"."title", "alexandria_core_document"."description", "alexandria_core_document"."category_id", "alexandria_core_document"."date" FROM "alexandria_core_document" WHERE "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid LIMIT 21',
       'SELECT "alexandria_core_category"."created_at", "alexandria_core_category"."created_by_user", "alexandria_core_category"."created_by_group", "alexandria_core_category"."modified_at", "alexandria_core_category"."modified_by_user", "alexandria_core_category"."modified_by_group", "alexandria_core_category"."metainfo", "alexandria_core_category"."slug", "alexandria_core_category"."name", "alexandria_core_category"."description", "alexandria_core_category"."allowed_mime_types", "alexandria_core_category"."color", "alexandria_core_category"."parent_id" FROM "alexandria_core_category" WHERE "alexandria_core_category"."slug" = \'note-act-source\' LIMIT 21',
-      'INSERT INTO "alexandria_core_file" ("created_at", "created_by_user", "created_by_group", "modified_at", "modified_by_user", "modified_by_group", "metainfo", "id", "variant", "original_id", "name", "document_id", "checksum", "encryption_status", "content", "mime_type", "size") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'{}\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, \'original\', NULL, \'Jason Lopez\', \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'sha256:945db0f84bf4ec45cf1c4835cb61848210d64c3867f5a3d78f55ca18e4a98879\', NULL, \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad_Jason_Lopez\', \'application/octet-stream\', 11)',
-      'INSERT INTO "alexandria_core_file" ("created_at", "created_by_user", "created_by_group", "modified_at", "modified_by_user", "modified_by_group", "metainfo", "id", "variant", "original_id", "name", "document_id", "checksum", "encryption_status", "content", "mime_type", "size") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, NULL, NULL, \'2017-05-21T00:00:00+00:00\'::timestamptz, NULL, NULL, \'{}\', \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid, \'thumbnail\', \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, \'Jason Lopez_preview.jpg\', \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'sha256:0b5121c3edeb9ac0ac4d2f2cfa34773e43b68017bba0dfc859bdfdeae4392cc2\', NULL, \'ea416ed0-759d-46a8-de58-f63a59077499_Jason_Lopez_preview.jpg\', \'image/jpeg\', 438)',
-      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'INSERT INTO "alexandria_core_file" ("created_at", "created_by_user", "created_by_group", "modified_at", "modified_by_user", "modified_by_group", "metainfo", "id", "variant", "original_id", "name", "document_id", "checksum", "encryption_status", "content", "mime_type", "size") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'2017-05-21T00:00:00+00:00\'::timestamptz, \'admin\', \'admin\', \'{}\', \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid, \'original\', NULL, \'Jason Lopez\', \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'sha256:945db0f84bf4ec45cf1c4835cb61848210d64c3867f5a3d78f55ca18e4a98879\', NULL, \'ea416ed0-759d-46a8-de58-f63a59077499_Jason_Lopez\', \'application/octet-stream\', 11)',
+      'SELECT COUNT(*) AS "__count" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid',
+      'INSERT INTO "alexandria_core_file" ("created_at", "created_by_user", "created_by_group", "modified_at", "modified_by_user", "modified_by_group", "metainfo", "id", "variant", "original_id", "name", "document_id", "checksum", "encryption_status", "content", "mime_type", "size") VALUES (\'2017-05-21T00:00:00+00:00\'::timestamptz, NULL, NULL, \'2017-05-21T00:00:00+00:00\'::timestamptz, NULL, NULL, \'{}\', \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid, \'thumbnail\', \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid, \'Jason Lopez_preview.jpg\', \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid, \'sha256:0b5121c3edeb9ac0ac4d2f2cfa34773e43b68017bba0dfc859bdfdeae4392cc2\', NULL, \'fb0e22c7-9ac7-5679-e988-1e6ba183b354_Jason_Lopez_preview.jpg\', \'image/jpeg\', 438)',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
       'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
     ]),
     'query_count': 7,
@@ -126,7 +126,7 @@
           'created-at': '2017-05-21T00:00:00Z',
           'created-by-group': 'admin',
           'created-by-user': 'admin',
-          'download-url': 'http://testserver/api/v1/files/f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad/download?expires=1495325100&signature=b1zEze_szPmFIwN-fjAHmUm-bLQ5NWr9YXPV7Fg9JWU',
+          'download-url': 'http://testserver/api/v1/files/ea416ed0-759d-46a8-de58-f63a59077499/download?expires=1495325100&signature=yomBR8YqKuSLguMHxfpQ2Myl2lywqF1v2GTbjBLg9a4',
           'metainfo': dict({
           }),
           'mime-type': 'application/octet-stream',
@@ -138,7 +138,7 @@
           'variant': 'original',
           'webdav-url': str,
         }),
-        'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+        'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
         'relationships': dict({
           'document': dict({
             'data': dict({
@@ -152,7 +152,7 @@
           'renderings': dict({
             'data': list([
               dict({
-                'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
+                'id': 'fb0e22c7-9ac7-5679-e988-1e6ba183b354',
                 'type': 'files',
               }),
             ]),
@@ -350,9 +350,10 @@
     'queries': list([
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid LIMIT 21',
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" IN (\'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid) ORDER BY "alexandria_core_file"."created_at" DESC',
-      'DELETE FROM "alexandria_core_file" WHERE "alexandria_core_file"."id" IN (\'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid)',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" IN (\'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid) ORDER BY "alexandria_core_file"."created_at" DESC',
+      'DELETE FROM "alexandria_core_file" WHERE "alexandria_core_file"."id" IN (\'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid)',
     ]),
-    'query_count': 3,
+    'query_count': 4,
     'request': dict({
       'PATH_INFO': '/api/v1/files/9336ebf2-5087-d91c-818e-e6e9ec29f8c1',
       'QUERY_STRING': '',
@@ -652,12 +653,15 @@
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size", T2."created_at", T2."created_by_user", T2."created_by_group", T2."modified_at", T2."modified_by_user", T2."modified_by_group", T2."metainfo", T2."id", T2."variant", T2."original_id", T2."name", T2."document_id", T2."checksum", T2."encryption_status", T2."content", T2."mime_type", T2."size", "alexandria_core_document"."created_at", "alexandria_core_document"."created_by_user", "alexandria_core_document"."created_by_group", "alexandria_core_document"."modified_at", "alexandria_core_document"."modified_by_user", "alexandria_core_document"."modified_by_group", "alexandria_core_document"."metainfo", "alexandria_core_document"."id", "alexandria_core_document"."title", "alexandria_core_document"."description", "alexandria_core_document"."category_id", "alexandria_core_document"."date" FROM "alexandria_core_file" LEFT OUTER JOIN "alexandria_core_file" T2 ON ("alexandria_core_file"."original_id" = T2."id") INNER JOIN "alexandria_core_document" ON ("alexandria_core_file"."document_id" = "alexandria_core_document"."id") WHERE "alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid LIMIT 21',
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" IN (\'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid) ORDER BY "alexandria_core_file"."created_at" DESC',
       'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid AND "alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
       'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
       'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid',
       'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid',
     ]),
-    'query_count': 7,
+    'query_count': 10,
     'request': dict({
       'CONTENT_TYPE': 'application/octet-stream',
       'PATH_INFO': '/api/v1/files/9336ebf2-5087-d91c-818e-e6e9ec29f8c1',
@@ -701,9 +705,13 @@
           }),
           'renderings': dict({
             'data': list([
+              dict({
+                'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+                'type': 'files',
+              }),
             ]),
             'meta': dict({
-              'count': 0,
+              'count': 1,
             }),
           }),
         }),
@@ -749,9 +757,13 @@
                   'id': '9336ebf2-5087-d91c-818e-e6e9ec29f8c1',
                   'type': 'files',
                 }),
+                dict({
+                  'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+                  'type': 'files',
+                }),
               ]),
               'meta': dict({
-                'count': 1,
+                'count': 2,
               }),
             }),
             'marks': dict({
@@ -770,6 +782,48 @@
             }),
           }),
           'type': 'documents',
+        }),
+        dict({
+          'attributes': dict({
+            'checksum': 'sha256:2326873dfaedc7d5aa551f9cc412cbfa32e96c0e1736ebea0ad48a649e61523f',
+            'created-at': '2017-05-21T00:00:00Z',
+            'created-by-group': None,
+            'created-by-user': None,
+            'download-url': 'http://testserver/api/v1/files/f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad/download?expires=1495325100&signature=b1zEze_szPmFIwN-fjAHmUm-bLQ5NWr9YXPV7Fg9JWU',
+            'metainfo': dict({
+            }),
+            'mime-type': 'image/jpeg',
+            'modified-at': '2017-05-21T00:00:00Z',
+            'modified-by-group': None,
+            'modified-by-user': None,
+            'name': 'Jason Lopez_preview.jpg',
+            'size': 1107,
+            'variant': 'thumbnail',
+            'webdav-url': NoneType,
+          }),
+          'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+          'relationships': dict({
+            'document': dict({
+              'data': dict({
+                'id': '9dd4e461-268c-8034-f5c8-564e155c67a6',
+                'type': 'documents',
+              }),
+            }),
+            'original': dict({
+              'data': dict({
+                'id': '9336ebf2-5087-d91c-818e-e6e9ec29f8c1',
+                'type': 'files',
+              }),
+            }),
+            'renderings': dict({
+              'data': list([
+              ]),
+              'meta': dict({
+                'count': 0,
+              }),
+            }),
+          }),
+          'type': 'files',
         }),
       ]),
     }),
@@ -1401,24 +1455,51 @@
   dict({
     'queries': list([
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size", T2."created_at", T2."created_by_user", T2."created_by_group", T2."modified_at", T2."modified_by_user", T2."modified_by_group", T2."metainfo", T2."id", T2."variant", T2."original_id", T2."name", T2."document_id", T2."checksum", T2."encryption_status", T2."content", T2."mime_type", T2."size", "alexandria_core_document"."created_at", "alexandria_core_document"."created_by_user", "alexandria_core_document"."created_by_group", "alexandria_core_document"."modified_at", "alexandria_core_document"."modified_by_user", "alexandria_core_document"."modified_by_group", "alexandria_core_document"."metainfo", "alexandria_core_document"."id", "alexandria_core_document"."title", "alexandria_core_document"."description", "alexandria_core_document"."category_id", "alexandria_core_document"."date" FROM "alexandria_core_file" LEFT OUTER JOIN "alexandria_core_file" T2 ON ("alexandria_core_file"."original_id" = T2."id") INNER JOIN "alexandria_core_document" ON ("alexandria_core_file"."document_id" = "alexandria_core_document"."id") ORDER BY "alexandria_core_file"."created_at" DESC',
-      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" IN (\'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'dad3a37a-a9d5-0688-b515-7698acfd7aee\'::uuid, \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" IN (\'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid, \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid, \'aba369f7-d2b2-8a90-98a0-a26feb7dc965\'::uuid, \'dad3a37a-a9d5-0688-b515-7698acfd7aee\'::uuid, \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid, \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid) ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid AND "alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid) LIMIT 1',
       'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
-      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid AND "alexandria_core_document"."id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid) LIMIT 1',
-      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid AND "alexandria_core_document"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid AND "alexandria_core_file"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid AND "alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid AND "alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid AND "alexandria_core_file"."id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid AND "alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid AND "alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid AND "alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
       'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
       'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
       'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid',
       'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid',
-      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid AND "alexandria_core_document"."id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid) LIMIT 1',
-      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
-      'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid',
-      'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid',
-      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid AND "alexandria_core_document"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid) LIMIT 1',
-      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
-      'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid',
-      'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid AND "alexandria_core_file"."id" = \'9336ebf2-5087-d91c-818e-e6e9ec29f8c1\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid AND "alexandria_core_document"."id" = \'9dd4e461-268c-8034-f5c8-564e155c67a6\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid AND "alexandria_core_file"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid AND "alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid AND "alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid',
+      'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid AND "alexandria_core_file"."id" = \'fb0e22c7-9ac7-5679-e988-1e6ba183b354\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'dad3a37a-a9d5-0688-b515-7698acfd7aee\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid AND "alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid AND "alexandria_core_document"."id" = \'ea416ed0-759d-46a8-de58-f63a59077499\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid AND "alexandria_core_file"."id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid AND "alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid AND "alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."document_id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT "alexandria_core_tag"."created_at", "alexandria_core_tag"."created_by_user", "alexandria_core_tag"."created_by_group", "alexandria_core_tag"."modified_at", "alexandria_core_tag"."modified_by_user", "alexandria_core_tag"."modified_by_group", "alexandria_core_tag"."metainfo", "alexandria_core_tag"."id", "alexandria_core_tag"."name", "alexandria_core_tag"."description", "alexandria_core_tag"."tag_synonym_group_id" FROM "alexandria_core_tag" INNER JOIN "alexandria_core_document_tags" ON ("alexandria_core_tag"."id" = "alexandria_core_document_tags"."tag_id") WHERE "alexandria_core_document_tags"."document_id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid',
+      'SELECT "alexandria_core_mark"."created_at", "alexandria_core_mark"."created_by_user", "alexandria_core_mark"."created_by_group", "alexandria_core_mark"."modified_at", "alexandria_core_mark"."modified_by_user", "alexandria_core_mark"."modified_by_group", "alexandria_core_mark"."metainfo", "alexandria_core_mark"."slug", "alexandria_core_mark"."name", "alexandria_core_mark"."description" FROM "alexandria_core_mark" INNER JOIN "alexandria_core_document_marks" ON ("alexandria_core_mark"."slug" = "alexandria_core_document_marks"."mark_id") WHERE "alexandria_core_document_marks"."document_id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid',
+      'SELECT (1) AS "a" FROM "alexandria_core_file" WHERE ("alexandria_core_file"."id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid AND "alexandria_core_file"."id" = \'0b0cfc07-fca8-1c95-6ab9-181d8576f4a8\'::uuid) LIMIT 1',
+      'SELECT "alexandria_core_file"."created_at", "alexandria_core_file"."created_by_user", "alexandria_core_file"."created_by_group", "alexandria_core_file"."modified_at", "alexandria_core_file"."modified_by_user", "alexandria_core_file"."modified_by_group", "alexandria_core_file"."metainfo", "alexandria_core_file"."id", "alexandria_core_file"."variant", "alexandria_core_file"."original_id", "alexandria_core_file"."name", "alexandria_core_file"."document_id", "alexandria_core_file"."checksum", "alexandria_core_file"."encryption_status", "alexandria_core_file"."content", "alexandria_core_file"."mime_type", "alexandria_core_file"."size" FROM "alexandria_core_file" WHERE "alexandria_core_file"."original_id" = \'aba369f7-d2b2-8a90-98a0-a26feb7dc965\'::uuid ORDER BY "alexandria_core_file"."created_at" DESC',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid AND "alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid) LIMIT 1',
+      'SELECT (1) AS "a" FROM "alexandria_core_document" WHERE ("alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid AND "alexandria_core_document"."id" = \'04adb4e2-f055-c978-c9bb-101ee1bc5cd4\'::uuid) LIMIT 1',
     ]),
-    'query_count': 17,
+    'query_count': 44,
     'request': dict({
       'CONTENT_TYPE': 'application/octet-stream',
       'PATH_INFO': '/api/v1/files',
@@ -1429,6 +1510,48 @@
     'request_payload': None,
     'response': dict({
       'data': list([
+        dict({
+          'attributes': dict({
+            'checksum': 'sha256:2326873dfaedc7d5aa551f9cc412cbfa32e96c0e1736ebea0ad48a649e61523f',
+            'created-at': '2017-05-21T00:00:00Z',
+            'created-by-group': None,
+            'created-by-user': None,
+            'download-url': 'http://testserver/api/v1/files/f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad/download?expires=1495325100&signature=b1zEze_szPmFIwN-fjAHmUm-bLQ5NWr9YXPV7Fg9JWU',
+            'metainfo': dict({
+            }),
+            'mime-type': 'image/jpeg',
+            'modified-at': '2017-05-21T00:00:00Z',
+            'modified-by-group': None,
+            'modified-by-user': None,
+            'name': 'Jason Lopez_preview.jpg',
+            'size': 1107,
+            'variant': 'thumbnail',
+            'webdav-url': NoneType,
+          }),
+          'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+          'relationships': dict({
+            'document': dict({
+              'data': dict({
+                'id': '9dd4e461-268c-8034-f5c8-564e155c67a6',
+                'type': 'documents',
+              }),
+            }),
+            'original': dict({
+              'data': dict({
+                'id': '9336ebf2-5087-d91c-818e-e6e9ec29f8c1',
+                'type': 'files',
+              }),
+            }),
+            'renderings': dict({
+              'data': list([
+              ]),
+              'meta': dict({
+                'count': 0,
+              }),
+            }),
+          }),
+          'type': 'files',
+        }),
         dict({
           'attributes': dict({
             'checksum': 'sha256:6e94c5bf30f49e56597aa0cddc0ec3953fe0f9d8cfc71d32b96bcde0372a1bd9',
@@ -1460,6 +1583,52 @@
             }),
             'renderings': dict({
               'data': list([
+                dict({
+                  'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+                  'type': 'files',
+                }),
+              ]),
+              'meta': dict({
+                'count': 1,
+              }),
+            }),
+          }),
+          'type': 'files',
+        }),
+        dict({
+          'attributes': dict({
+            'checksum': 'sha256:2326873dfaedc7d5aa551f9cc412cbfa32e96c0e1736ebea0ad48a649e61523f',
+            'created-at': '2017-05-21T00:00:00Z',
+            'created-by-group': None,
+            'created-by-user': None,
+            'download-url': 'http://testserver/api/v1/files/dad3a37a-a9d5-0688-b515-7698acfd7aee/download?expires=1495325100&signature=BMH4YYFT0xydudBRTrGP43GD25pBXDugqT265PD6M34',
+            'metainfo': dict({
+            }),
+            'mime-type': 'image/jpeg',
+            'modified-at': '2017-05-21T00:00:00Z',
+            'modified-by-group': None,
+            'modified-by-user': None,
+            'name': 'Rebecca Gonzalez_preview.jpg',
+            'size': 1107,
+            'variant': 'thumbnail',
+            'webdav-url': NoneType,
+          }),
+          'id': 'dad3a37a-a9d5-0688-b515-7698acfd7aee',
+          'relationships': dict({
+            'document': dict({
+              'data': dict({
+                'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
+                'type': 'documents',
+              }),
+            }),
+            'original': dict({
+              'data': dict({
+                'id': 'fb0e22c7-9ac7-5679-e988-1e6ba183b354',
+                'type': 'files',
+              }),
+            }),
+            'renderings': dict({
+              'data': list([
               ]),
               'meta': dict({
                 'count': 0,
@@ -1474,7 +1643,7 @@
             'created-at': '2017-05-21T00:00:00Z',
             'created-by-group': 'admin',
             'created-by-user': 'admin',
-            'download-url': 'http://testserver/api/v1/files/ea416ed0-759d-46a8-de58-f63a59077499/download?expires=1495325100&signature=yomBR8YqKuSLguMHxfpQ2Myl2lywqF1v2GTbjBLg9a4',
+            'download-url': 'http://testserver/api/v1/files/fb0e22c7-9ac7-5679-e988-1e6ba183b354/download?expires=1495325100&signature=3hcV0trdfBrBgkmk2Z2jYRX1WW6fLqhgF2nDuR1i8FM',
             'metainfo': dict({
             }),
             'mime-type': 'model/vrml',
@@ -1486,16 +1655,62 @@
             'variant': 'original',
             'webdav-url': str,
           }),
-          'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
+          'id': 'fb0e22c7-9ac7-5679-e988-1e6ba183b354',
           'relationships': dict({
             'document': dict({
               'data': dict({
-                'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+                'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
                 'type': 'documents',
               }),
             }),
             'original': dict({
               'data': None,
+            }),
+            'renderings': dict({
+              'data': list([
+                dict({
+                  'id': 'dad3a37a-a9d5-0688-b515-7698acfd7aee',
+                  'type': 'files',
+                }),
+              ]),
+              'meta': dict({
+                'count': 1,
+              }),
+            }),
+          }),
+          'type': 'files',
+        }),
+        dict({
+          'attributes': dict({
+            'checksum': 'sha256:2326873dfaedc7d5aa551f9cc412cbfa32e96c0e1736ebea0ad48a649e61523f',
+            'created-at': '2017-05-21T00:00:00Z',
+            'created-by-group': None,
+            'created-by-user': None,
+            'download-url': 'http://testserver/api/v1/files/aba369f7-d2b2-8a90-98a0-a26feb7dc965/download?expires=1495325100&signature=4xjmQ82ETHQJpGpKPgLOzm1B4_Cq6qLVyWcMrcT35Ms',
+            'metainfo': dict({
+            }),
+            'mime-type': 'image/jpeg',
+            'modified-at': '2017-05-21T00:00:00Z',
+            'modified-by-group': None,
+            'modified-by-user': None,
+            'name': 'Nicole Pineda_preview.jpg',
+            'size': 1107,
+            'variant': 'thumbnail',
+            'webdav-url': NoneType,
+          }),
+          'id': 'aba369f7-d2b2-8a90-98a0-a26feb7dc965',
+          'relationships': dict({
+            'document': dict({
+              'data': dict({
+                'id': '04adb4e2-f055-c978-c9bb-101ee1bc5cd4',
+                'type': 'documents',
+              }),
+            }),
+            'original': dict({
+              'data': dict({
+                'id': '0b0cfc07-fca8-1c95-6ab9-181d8576f4a8',
+                'type': 'files',
+              }),
             }),
             'renderings': dict({
               'data': list([
@@ -1513,7 +1728,7 @@
             'created-at': '2017-05-21T00:00:00Z',
             'created-by-group': 'admin',
             'created-by-user': 'admin',
-            'download-url': 'http://testserver/api/v1/files/dad3a37a-a9d5-0688-b515-7698acfd7aee/download?expires=1495325100&signature=BMH4YYFT0xydudBRTrGP43GD25pBXDugqT265PD6M34',
+            'download-url': 'http://testserver/api/v1/files/0b0cfc07-fca8-1c95-6ab9-181d8576f4a8/download?expires=1495325100&signature=VZ9EOGgzQS2KfGailvW9QAXdR85VE0H40zUsdlpzamc',
             'metainfo': dict({
             }),
             'mime-type': 'model/x3d+xml',
@@ -1525,11 +1740,11 @@
             'variant': 'original',
             'webdav-url': str,
           }),
-          'id': 'dad3a37a-a9d5-0688-b515-7698acfd7aee',
+          'id': '0b0cfc07-fca8-1c95-6ab9-181d8576f4a8',
           'relationships': dict({
             'document': dict({
               'data': dict({
-                'id': 'fb0e22c7-9ac7-5679-e988-1e6ba183b354',
+                'id': '04adb4e2-f055-c978-c9bb-101ee1bc5cd4',
                 'type': 'documents',
               }),
             }),
@@ -1538,9 +1753,13 @@
             }),
             'renderings': dict({
               'data': list([
+                dict({
+                  'id': 'aba369f7-d2b2-8a90-98a0-a26feb7dc965',
+                  'type': 'files',
+                }),
               ]),
               'meta': dict({
-                'count': 0,
+                'count': 1,
               }),
             }),
           }),
@@ -1548,6 +1767,68 @@
         }),
       ]),
       'included': list([
+        dict({
+          'attributes': dict({
+            'created-at': '2017-05-21T00:00:00Z',
+            'created-by-group': 'admin',
+            'created-by-user': 'admin',
+            'date': '1973-06-29',
+            'description': dict({
+              'de': '',
+              'en': 'Agency season worry take value eye sell. He consumer same season natural think Mr. Loss increase firm friend ability. Their office though television return main.',
+              'fr': '',
+            }),
+            'metainfo': dict({
+            }),
+            'modified-at': '2017-05-21T00:00:00Z',
+            'modified-by-group': 'admin',
+            'modified-by-user': 'admin',
+            'title': dict({
+              'de': '',
+              'en': 'Thomas Hernandez',
+              'fr': '',
+            }),
+          }),
+          'id': '04adb4e2-f055-c978-c9bb-101ee1bc5cd4',
+          'relationships': dict({
+            'category': dict({
+              'data': dict({
+                'id': 'moment-poor',
+                'type': 'categories',
+              }),
+            }),
+            'files': dict({
+              'data': list([
+                dict({
+                  'id': '0b0cfc07-fca8-1c95-6ab9-181d8576f4a8',
+                  'type': 'files',
+                }),
+                dict({
+                  'id': 'aba369f7-d2b2-8a90-98a0-a26feb7dc965',
+                  'type': 'files',
+                }),
+              ]),
+              'meta': dict({
+                'count': 2,
+              }),
+            }),
+            'marks': dict({
+              'data': list([
+              ]),
+              'meta': dict({
+                'count': 0,
+              }),
+            }),
+            'tags': dict({
+              'data': list([
+              ]),
+              'meta': dict({
+                'count': 0,
+              }),
+            }),
+          }),
+          'type': 'documents',
+        }),
         dict({
           'attributes': dict({
             'created-at': '2017-05-21T00:00:00Z',
@@ -1587,9 +1868,13 @@
                   'id': '9336ebf2-5087-d91c-818e-e6e9ec29f8c1',
                   'type': 'files',
                 }),
+                dict({
+                  'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+                  'type': 'files',
+                }),
               ]),
               'meta': dict({
-                'count': 1,
+                'count': 2,
               }),
             }),
             'marks': dict({
@@ -1634,7 +1919,7 @@
               'fr': '',
             }),
           }),
-          'id': 'f561aaf6-ef0b-f14d-4208-bb46a4ccb3ad',
+          'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
           'relationships': dict({
             'category': dict({
               'data': dict({
@@ -1645,70 +1930,16 @@
             'files': dict({
               'data': list([
                 dict({
-                  'id': 'ea416ed0-759d-46a8-de58-f63a59077499',
+                  'id': 'fb0e22c7-9ac7-5679-e988-1e6ba183b354',
                   'type': 'files',
                 }),
-              ]),
-              'meta': dict({
-                'count': 1,
-              }),
-            }),
-            'marks': dict({
-              'data': list([
-              ]),
-              'meta': dict({
-                'count': 0,
-              }),
-            }),
-            'tags': dict({
-              'data': list([
-              ]),
-              'meta': dict({
-                'count': 0,
-              }),
-            }),
-          }),
-          'type': 'documents',
-        }),
-        dict({
-          'attributes': dict({
-            'created-at': '2017-05-21T00:00:00Z',
-            'created-by-group': 'admin',
-            'created-by-user': 'admin',
-            'date': '1973-06-29',
-            'description': dict({
-              'de': '',
-              'en': 'Agency season worry take value eye sell. He consumer same season natural think Mr. Loss increase firm friend ability. Their office though television return main.',
-              'fr': '',
-            }),
-            'metainfo': dict({
-            }),
-            'modified-at': '2017-05-21T00:00:00Z',
-            'modified-by-group': 'admin',
-            'modified-by-user': 'admin',
-            'title': dict({
-              'de': '',
-              'en': 'Thomas Hernandez',
-              'fr': '',
-            }),
-          }),
-          'id': 'fb0e22c7-9ac7-5679-e988-1e6ba183b354',
-          'relationships': dict({
-            'category': dict({
-              'data': dict({
-                'id': 'moment-poor',
-                'type': 'categories',
-              }),
-            }),
-            'files': dict({
-              'data': list([
                 dict({
                   'id': 'dad3a37a-a9d5-0688-b515-7698acfd7aee',
                   'type': 'files',
                 }),
               ]),
               'meta': dict({
-                'count': 1,
+                'count': 2,
               }),
             }),
             'marks': dict({

--- a/alexandria/core/tests/test_dav.py
+++ b/alexandria/core/tests/test_dav.py
@@ -58,11 +58,15 @@ def test_dav(db, manabi, settings, s3, file_factory, use_s3, same_user):
 
         file.refresh_from_db()
         new_file = file
-        document_files_count = 1
+        document_files_count = 2
         if not same_user:
-            document_files_count = 2
+            document_files_count = 4
             new_file = (
-                File.objects.filter(document=file.document).exclude(pk=file.pk).first()
+                File.objects.filter(
+                    document=file.document, variant=File.Variant.ORIGINAL
+                )
+                .exclude(pk=file.pk)
+                .first()
             )
             assert file.modified_by_user == file.modified_by_group == "admin"
 

--- a/alexandria/core/tests/test_views.py
+++ b/alexandria/core/tests/test_views.py
@@ -281,12 +281,16 @@ def test_multi_download(admin_client, file_factory):
     assert len(zip.filelist) == 4
     filelist = sorted(zip.filelist, key=lambda a: a.filename)
     assert filelist[0].filename == "a_file"
+    file2.content.file.seek(0)
     assert zip.open("a_file").read() == file2.content.file.read()
     assert filelist[1].filename == "a_file(1)"
+    file1.content.file.seek(0)
     assert zip.open("a_file(1)").read() == file1.content.file.read()
     assert filelist[2].filename == "a_file(2)"
+    file3.content.file.seek(0)
     assert zip.open("a_file(2)").read() == file3.content.file.read()
     assert filelist[3].filename == "b_file.png"
+    file4.content.file.seek(0)
     assert zip.open(file4.name).read() == file4.content.file.read()
 
 
@@ -413,7 +417,7 @@ def test_convert_document(
     assert response.status_code == HTTP_201_CREATED
 
     assert Document.objects.all().count() == 2
-    assert File.objects.all().count() == 3
+    assert File.objects.all().count() == 4
     assert File.objects.filter(name="foo.pdf", variant=File.Variant.ORIGINAL).exists()
 
 

--- a/alexandria/core/tests/test_viewsets.py
+++ b/alexandria/core/tests/test_viewsets.py
@@ -154,7 +154,7 @@ def assert_response(
     assert value == snapshot(
         matcher=path_type(
             {
-                ".*webdav-url": (str,),
+                ".*webdav-url": (str, type(None)),
             },
             regex=True,
         )

--- a/alexandria/core/tests/test_visibility.py
+++ b/alexandria/core/tests/test_visibility.py
@@ -89,4 +89,4 @@ def test_own_and_admin_visibility(
     assert len(resp.json()["data"]) == expected_count
 
     resp = client.get(reverse("file-list"))
-    assert len(resp.json()["data"]) == expected_count
+    assert len(resp.json()["data"]) == expected_count * 2

--- a/alexandria/core/validations.py
+++ b/alexandria/core/validations.py
@@ -1,0 +1,47 @@
+from mimetypes import guess_type
+
+from django.utils.translation import gettext_lazy as _
+from django_clamd.validators import validate_file_infection
+from generic_permissions.validation import validator_for
+from rest_framework.exceptions import ValidationError
+
+from alexandria.core.models import File
+
+
+def validate_file(file):
+    validate_file_infection(file.content)
+    validate_mime_type(file.mime_type, file.document.category)
+
+
+def validate_mime_type(mime_type, category):
+    if (
+        category.allowed_mime_types is not None
+        and len(category.allowed_mime_types)
+        and mime_type not in category.allowed_mime_types
+    ):
+        raise ValidationError(
+            _(
+                "File type %(mime_type)s is not allowed in category %(category)s."
+                % {"mime_type": mime_type, "category": category.pk}
+            )
+        )
+
+    return True
+
+
+class AlexandriaValidator:
+    @validator_for(File)
+    def validate_file(self, data, context):
+        validate_file_infection(data["content"])
+
+        # Validate that the mime type is allowed in the category
+        mime_type = data["content"].content_type
+        if mime_type == "application/octet-stream" or not mime_type:
+            guess, encoding = guess_type(data["name"])
+            if guess is not None:
+                mime_type = guess
+
+        validate_mime_type(mime_type, data["document"].category)
+        data["mime_type"] = mime_type
+
+        return data

--- a/alexandria/settings/alexandria.py
+++ b/alexandria/settings/alexandria.py
@@ -70,7 +70,10 @@ ALEXANDRIA_PERMISSION_CLASSES = env.list(
     "ALEXANDRIA_PERMISSION_CLASSES",
     default=default(["generic_permissions.permissions.AllowAny"], []),
 )
-ALEXANDRIA_VALIDATION_CLASSES = env.list("ALEXANDRIA_VALIDATION_CLASSES", default=[])
+ALEXANDRIA_VALIDATION_CLASSES = env.list(
+    "ALEXANDRIA_VALIDATION_CLASSES",
+    default=["alexandria.core.validations.AlexandriaValidator"],
+)
 
 # We use DGAP as a permission/visibility/validation handler. Copy
 # the configuration over so DGAP knows

--- a/alexandria/storages/tests/test_dynamic_field.py
+++ b/alexandria/storages/tests/test_dynamic_field.py
@@ -21,6 +21,7 @@ def test_dynamic_storage_select_global_ssec(
     settings.ALEXANDRIA_S3_STORAGE_SSEC_SECRET = secret
 
     mocker.patch("storages.backends.s3.S3Storage.save")
+    mocker.patch("alexandria.core.models.File.create_thumbnail")
     SsecGlobalS3Storage.save.return_value = "name-of-the-file"
     if raises is not None:
         with pytest.raises(raises):


### PR DESCRIPTION
This way, the same validations are also triggered when files are uploaded via the python API.