### PR TITLE
fix(tika): use module path imports

### DIFF
--- a/alexandria/core/models.py
+++ b/alexandria/core/models.py
@@ -6,7 +6,8 @@ from mimetypes import guess_extension
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import tika
+import tika.language
+import tika.parser
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex

--- a/alexandria/core/tests/test_commands.py
+++ b/alexandria/core/tests/test_commands.py
@@ -1,7 +1,8 @@
 from io import StringIO
 
 import pytest
-import tika
+import tika.language
+import tika.parser
 from django.core.files import File as DjangoFile
 from django.core.management import call_command
 

--- a/alexandria/core/tests/test_views.py
+++ b/alexandria/core/tests/test_views.py
@@ -4,7 +4,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
-import tika
+import tika.parser
 from django.urls import reverse
 from django.utils import timezone
 from factory.django import django_files


### PR DESCRIPTION
has some weirdness when using `import tika` instead of the modules directly, sometimes the import works other times it errors with a module not found through `tika.parser`