### PR TITLE
feat(file): search over all configured stemmings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ test: ## Test the backend
 lint: ## Lint the backend
 	@docker compose run --rm alexandria sh -c "poetry run black --check . && poetry run flake8"
 
+.PHONY: format
+format: ## format the backend
+	@docker compose run --rm alexandria sh -c "poetry run black . && poetry run isort ."
+
 .PHONY: bash
 bash: ## Shell into the backend
 	@docker compose run --rm alexandria bash

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ manabi.keygen()
 #### File content search (optional)
 
 - `ALEXANDRIA_ENABLE_CONTENT_SEARCH`: Set to `True` to enable file content extraction
+- `ALEXANDRIA_ISO_639_TO_PSQL_SEARCH_CONFIG`: Mapping from language code from tika to django search vector language config. Also defines which languages are supported by the search. (default: `{"en":"english","de":"german","fr":"french","it":"italian"}`)
+- `ALEXANDRIA_CONTENT_SEARCH_TYPE`: Django full text search type. (default: phrase)
 
 #### Development
 

--- a/alexandria/core/models.py
+++ b/alexandria/core/models.py
@@ -262,9 +262,10 @@ class File(UUIDModel):
             return
 
         # use part of content for language detection, beacause metadata is not reliable
-        detected_language = tika.language.from_buffer(parsed_content["content"][:1000])
-        self.language = detected_language
-        config = settings.ISO_639_TO_PSQL_SEARCH_CONFIG.get(detected_language, "simple")
+        self.language = tika.language.from_buffer(parsed_content["content"][:1000])
+        config = settings.ALEXANDRIA_ISO_639_TO_PSQL_SEARCH_CONFIG.get(
+            self.language, "simple"
+        )
         self.content_vector = name_vector + SearchVector(
             Value(parsed_content["content"]),
             config=config,

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -301,14 +301,22 @@ class SearchViewSet(
     def filter_queryset(self, queryset):
         query = self.request.query_params.get("filter[query]")
 
-        search_queries = []
-        for lang, desc in settings.LANGUAGES:
-            config = settings.ISO_639_TO_PSQL_SEARCH_CONFIG.get(lang, "simple")
+        search_queries = [
+            Q(
+                content_vector=SearchQuery(
+                    query,
+                    config="simple",
+                    search_type=settings.ALEXANDRIA_CONTENT_SEARCH_TYPE,
+                )
+            )
+        ]
+        for lang, config in settings.ALEXANDRIA_ISO_639_TO_PSQL_SEARCH_CONFIG.items():
             search_queries.append(
-                Q(language=lang)
-                & Q(
+                Q(
                     content_vector=SearchQuery(
-                        query, config=config, search_type="phrase"
+                        query,
+                        config=config,
+                        search_type=settings.ALEXANDRIA_CONTENT_SEARCH_TYPE,
                     )
                 )
             )

--- a/alexandria/settings/alexandria.py
+++ b/alexandria/settings/alexandria.py
@@ -205,9 +205,15 @@ MANABI_SECURE = True if ENV == "production" else False
 ALEXANDRIA_ENABLE_CONTENT_SEARCH = env.bool(
     "ALEXANDRIA_ENABLE_CONTENT_SEARCH", default=False
 )
-ISO_639_TO_PSQL_SEARCH_CONFIG = {
-    "en": "english",
-    "de": "german",
-    "fr": "french",
-    "it": "italian",
-}
+ALEXANDRIA_ISO_639_TO_PSQL_SEARCH_CONFIG = env.dict(
+    "ALEXANDRIA_ISO_639_TO_PSQL_SEARCH_CONFIG",
+    default={
+        "en": "english",
+        "de": "german",
+        "fr": "french",
+        "it": "italian",
+    },
+)
+ALEXANDRIA_CONTENT_SEARCH_TYPE = env.str(
+    "ALEXANDRIA_CONTENT_SEARCH_TYPE", default="phrase"
+)


### PR DESCRIPTION
This prevents files from being not findable when there is no content or a wrong language is detected.

This might make the search a little slower, as were not filtering for the language anymore. But files can always be found, even if the language which tika detected it not in the `LANGUAGE` setting.