### PR TITLE
fix(file): clone files with s3 copy

### DIFF
--- a/alexandria/core/tests/test_models.py
+++ b/alexandria/core/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.files import File as DjangoFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import ObjectDoesNotExist
 
@@ -50,3 +51,44 @@ def test_document_no_files(
         document.get_latest_original()
     except ObjectDoesNotExist:
         assert True
+
+
+def test_clone_document_s3(db, mocker, settings, file_factory):
+    settings.ALEXANDRIA_FILE_STORAGE = (
+        "alexandria.storages.backends.s3.SsecGlobalS3Storage"
+    )
+    settings.ALEXANDRIA_ENABLE_AT_REST_ENCRYPTION = True
+    name = "name-of-the-file"
+    mocker.patch("storages.backends.s3.S3Storage.save", return_value=name)
+    mocker.patch(
+        "storages.backends.s3.S3Storage.open",
+        return_value=DjangoFile(open("README.md", "rb")),
+    )
+    mocked = mocker.patch("botocore.client.BaseClient._make_api_call")
+
+    original_file = file_factory(
+        variant=File.Variant.ORIGINAL,
+        content=SimpleUploadedFile(
+            name="test.png",
+            content=FileData.png,
+            content_type="image/png",
+        ),
+    )
+
+    file_factory(
+        original=original_file,
+        variant=File.Variant.THUMBNAIL,
+        document=original_file.document,
+    )
+
+    original_document_pk = original_file.document.pk
+
+    clone = original_file.document.clone()
+    original = Document.objects.get(pk=original_document_pk)
+
+    assert clone.pk != original.pk
+    assert (
+        clone.get_latest_original().content.name
+        != original.get_latest_original().content.name
+    )
+    assert mocked.call_args[0][1]["CopySource"]["Key"] == name

--- a/alexandria/storages/fields.py
+++ b/alexandria/storages/fields.py
@@ -27,6 +27,10 @@ class DynamicStorageFileField(models.FileField):
     # the storage code into it's own project, so we can reuse it outside
     # of Alexandria: https://github.com/projectcaluma/alexandria/issues/480
 
+    def __init__(self, storage=None, **kwargs):
+        storage = storages.create_storage({"BACKEND": settings.ALEXANDRIA_FILE_STORAGE})
+        super().__init__(storage=storage, **kwargs)
+
     def pre_save(self, instance, add):
         # set storage to default storage class to prevent reusing the last selection
         self.storage = storages.create_storage(


### PR DESCRIPTION
Use boto3 built in copy for cloning s3 files instead of fetching and reuploading the same content.

This change should substantially speed up cloning large amount of documents in a real environment with network latency. Locally the difference is not noticeable through the docker network.