### PR TITLE
ci(ghcr): run ghcr on publish an not on created

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -2,7 +2,7 @@ name: Container image
 
 on:
   release:
-    types: [created]
+    types: [published]
 
   # Run build for any PRs - we won't push in those however
   pull_request:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,7 +2,7 @@ name: PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
If a release was created from a draft release,
the created event is not fired but the published is.