### PR TITLE
fix(file): prevent validation exception for presigned url expiry

### DIFF
--- a/alexandria/core/tests/test_views.py
+++ b/alexandria/core/tests/test_views.py
@@ -484,6 +484,16 @@ def test_download_file(admin_client, file, presigned, expected_status):
     assert result.status_code == expected_status
 
 
+def test_download_file_expired(admin_client, file, freezer):
+    freezer.move_to("2025-03-20")
+    response = admin_client.get(reverse("file-detail", args=(file.pk,)))
+    url = response.json()["data"]["attributes"]["download-url"]
+    freezer.move_to("2025-03-21")
+
+    result = admin_client.get(url)
+    assert result.status_code == HTTP_403_FORBIDDEN
+
+
 @pytest.mark.parametrize(
     "mime_type,expected_content_disposition",
     [("application/pdf", "inline"), ("text/html", "attachment")],

--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -271,10 +271,15 @@ class FileViewSet(
     @permission_classes([AllowAny])
     @action(methods=["get"], detail=True)
     def download(self, request, pk=None):
-        if not verify_presigned_request(reverse("file-download", args=[pk]), request):
-            raise PermissionDenied(
-                _("For downloading a file use the presigned download URL.")
-            )
+        try:
+            if not verify_presigned_request(
+                reverse("file-download", args=[pk]), request
+            ):
+                raise PermissionDenied(
+                    _("For downloading a file use the presigned download URL.")
+                )
+        except DjangoCoreValidationError as exp:
+            raise PermissionDenied(*exp.messages)
 
         obj = models.File.objects.get(pk=pk)
 


### PR DESCRIPTION
Should we try to redirect to leave the user on the blank browser default 403 page?