### PR TITLE
Fix file copying

### DIFF
--- a/alexandria/core/api.py
+++ b/alexandria/core/api.py
@@ -41,20 +41,18 @@ def copy_document(
     document_files = models.File.objects.filter(
         document=document, variant=models.File.Variant.ORIGINAL.value
     ).order_by("created_at")
-    new_files = []
     for document_file in document_files:
-        new_files.append(
-            create_file(
-                name=document_file.name,
-                document=new_document,
-                content=document_file.content,
-                mime_type=document_file.mime_type,
-                size=document_file.size,
-                user=document_file.created_by_user,
-                group=document_file.created_by_group,
-                metainfo=document_file.metainfo,
-            )
+        new_file = create_file(
+            name=document_file.name,
+            document=new_document,
+            content=document_file.content,
+            mime_type=document_file.mime_type,
+            size=document_file.size,
+            user=document_file.created_by_user,
+            group=document_file.created_by_group,
+            metainfo=document_file.metainfo,
         )
+        new_file.content.copy(f"{new_file.pk}_{new_file.name}")
 
     return new_document
 

--- a/alexandria/core/management/commands/fix_copied_file_references.py
+++ b/alexandria/core/management/commands/fix_copied_file_references.py
@@ -1,0 +1,108 @@
+from collections import defaultdict
+
+import botocore
+from django.core.management.base import BaseCommand
+from tqdm import tqdm
+
+from alexandria.core.models import File
+
+
+class Command(BaseCommand):
+    help = "Fixes copied file references by creating a new copy."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry", dest="dry", action="store_true", default=False)
+        parser.add_argument("--since", dest="since", type=str, default=None)
+
+    def handle(self, *args, **options):
+        filename_counts = defaultdict(list)
+        file_list = File.objects.filter(variant="original")
+
+        for tmp_file in tqdm(file_list.order_by("created_at").iterator()):
+            filename = tmp_file.content.name
+            filename_counts[filename].append(tmp_file.pk)
+
+        fix_count = 0
+        for filename, pks in filename_counts.items():
+            # Skip files that only have one reference.
+            pks_len = len(pks)
+            if pks_len <= 1:
+                continue
+
+            duplicates_query = File.objects.filter(pk__in=pks).order_by("created_at")
+
+            # Filter copies by file creation timestamp if provided
+            if options["since"]:
+                duplicates_query = duplicates_query.filter(
+                    created_at__gt=options["since"]
+                )
+
+            original_duplicate, *duplicates = duplicates_query
+
+            ignored_output = ""
+            duplicates_len = len(duplicates)
+            if duplicates_len < (pks_len - 1):
+                ignored_len = pks_len - duplicates_len
+                ignored_output = f"/{pks_len} (ignored {ignored_len} files older than {options['since']})"
+
+            checksum = original_duplicate.checksum
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Fixing filename "{filename}" with {duplicates_len}{ignored_output} duplicate(s)'
+                )
+            )
+
+            for duplicate in duplicates:
+                # Check if the duplicate has a checksum and skip if it does not match
+                # the original. If it does not have a checksum, we try to copy the
+                # original file.
+                if duplicate.checksum and duplicate.checksum != checksum:
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f"Failed: File ID {duplicate.pk} with filename {filename} has a different checksum than the original."
+                        )
+                    )
+                    continue
+
+                new_filename = f"{duplicate.pk}_{duplicate.name}"
+
+                try:
+                    # perform the copy operation
+                    if not options["dry"]:
+                        duplicate.content.copy(f"{duplicate.pk}_{duplicate.name}")
+
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f" > Fixed file ID {duplicate.pk} with new filename {new_filename} (Checksum: {checksum})"
+                        )
+                    )
+                    fix_count += 1
+                except botocore.exceptions.ClientError as e:
+                    if e.response["Error"]["Code"] == "NoSuchKey":
+                        self.stderr.write(
+                            self.style.ERROR(
+                                f" > Failed: File ID {duplicate.pk} with filename {duplicate.content.name} does not exist in S3. (Checksum: {checksum})"
+                            )
+                        )
+                    else:
+                        self.stderr.write(
+                            self.style.ERROR(
+                                f" > Failed: Error while fixing File ID {duplicate.pk} with filename {duplicate.content.name}, client error: {e} (Checksum: {checksum})"
+                            )
+                        )
+                except Exception as e:
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f" > Failed: Error while fixing File ID {duplicate.pk} with filename {duplicate.content.name}, error: {e} (Checksum: {checksum})"
+                        )
+                    )
+
+        self.stdout.write("")
+        if fix_count > 0:
+            self.stdout.write(
+                self.style.SUCCESS(f"Fixed {fix_count} files with copied references.")
+            )
+        else:
+            self.stdout.write(
+                self.style.WARNING("No files with copied references where fixed.")
+            )

--- a/alexandria/core/tests/test_api.py
+++ b/alexandria/core/tests/test_api.py
@@ -87,6 +87,8 @@ def test_copy_document_api(db, category, category_factory, same_category):
     # files will retain the user/group of the original document
     assert files[0].created_by_user == "Foo"
     assert files[0].created_by_group == "Baz"
+    # copied file content should have a new name
+    assert str(files[0].content) != str(first_file.content)
 
     # new thumbnail for first file
     assert files[2].document.pk == copied_doc.pk
@@ -99,6 +101,8 @@ def test_copy_document_api(db, category, category_factory, same_category):
     assert files[1].name == "Mee2.pdf"
     assert files[1].mime_type == "image/jpeg"
     assert files[1].size == 2
+    # copied file content should have a new name
+    assert str(files[1].content) != str(extra_file.content)
     # files will retain the user/group of the original document
     assert files[1].created_by_user == "Foo2"
     assert files[1].created_by_group == "Baz2"
@@ -106,3 +110,67 @@ def test_copy_document_api(db, category, category_factory, same_category):
     # new thumbnail for extra file
     assert files[3].document.pk == copied_doc.pk
     assert files[3].variant == File.Variant.THUMBNAIL
+
+
+def test_copy_document_deleted_original(db, category_factory):
+    """
+    Test that copied files are still readable after the original document is deleted.
+    """
+    category = category_factory()
+    doc, _first_file = api.create_document_file(
+        user="Foo",
+        group="Baz",
+        category=category,
+        document_title="Bar.pdf",
+        file_name="Mee.pdf",
+        file_content=SimpleUploadedFile(
+            name="test.png",
+            content=FileData.png,
+            content_type="png",
+        ),
+        mime_type="image/png",
+        file_size=1,
+    )
+    api.create_file(
+        document=doc,
+        user="Foo2",
+        group="Baz2",
+        name="Mee2.pdf",
+        content=SimpleUploadedFile(
+            name="test2.png",
+            content=FileData.png800,
+            content_type="png",
+        ),
+        mime_type="image/jpeg",
+        size=2,
+    )
+
+    copied_doc = api.copy_document(doc, "CopyUser", "CopyGroup", category)
+    files = doc.files.filter(variant="original").order_by("variant", "created_at")
+    files_copied = copied_doc.files.filter(variant="original").order_by(
+        "variant", "created_at"
+    )
+
+    def _filecontent_is_readable(file):
+        """
+        Helper function to check if the file content is readable.
+        """
+        content = file.content
+        content.open()
+        try:
+            return content.readable()
+        finally:
+            content.close()
+
+    # check if original and copied files are readable.
+    assert _filecontent_is_readable(files[0])
+    assert _filecontent_is_readable(files[1])
+    assert _filecontent_is_readable(files_copied[0])
+    assert _filecontent_is_readable(files_copied[1])
+    assert files[0].content.name != files_copied[0].content.name
+    assert files[1].content.name != files_copied[1].content.name
+
+    # delete original doc and check if copied files are still readable.
+    doc.delete()
+    assert _filecontent_is_readable(files_copied[0])
+    assert _filecontent_is_readable(files_copied[1])

--- a/alexandria/storages/fields.py
+++ b/alexandria/storages/fields.py
@@ -35,11 +35,11 @@ class DynamicStorageFieldFile(FieldFile):
         if isinstance(self.storage, S3Storage):
             copy_args = {
                 "CopySource": {
-                    "Bucket": self.storage.bucket,
+                    "Bucket": self.storage.bucket.name,
                     "Key": self.name,
                 },
                 # Destination settings
-                "Bucket": self.storage.bucket,
+                "Bucket": self.storage.bucket.name,
                 "Key": target_name,
             }
             if isinstance(self.storage, SsecGlobalS3Storage):


### PR DESCRIPTION
This is a follow-up on both #757 and #798:

 * Pass the bucket *name* to Django storages (not the bucket *object*).
 * Copy the `FieldFile` object when copying a document's file, to prevent both files referencing the same object in the storage.