### PR TITLE
fix(webdav): close db connections if unused or obsolete

### DIFF
--- a/alexandria/dav.py
+++ b/alexandria/dav.py
@@ -1,13 +1,59 @@
+from functools import partial
+from typing import Any, Callable, Dict, List, Tuple
+
 from django.conf import settings
+from django.db import connections
 from manabi import ManabiAuthenticator, ManabiDAVApp
 from manabi.lock import ManabiDbLockStorage
 from manabi.log import HeaderLogger
 from wsgidav.dir_browser import WsgiDavDirBrowser
 from wsgidav.error_printer import ErrorPrinter
+from wsgidav.mw.base_mw import BaseMiddleware
 from wsgidav.mw.debug_filter import WsgiDavDebugFilter
 from wsgidav.request_resolver import RequestResolver
 
 from .dav_provider import AlexandriaProvider
+
+
+class ManageDjangoConnectionsMiddleware(BaseMiddleware):
+    """
+    Middleware for managing Django DB connections.
+
+    Disconnect DB connections that are not used anymore, or that have expired
+    or are broken. This is doing the same thing that Django would do at the
+    end of each request.
+
+    Note: This middleware should be the first in the stack, as any middleware
+    that are above it will not be able to use Django DB / models anymore after
+    the request is processed
+    """
+
+    def __call__(
+        self, environ: Dict[str, Any], start_response: Callable
+    ) -> List[bytes]:
+        self.cleanup_db_connections()
+        return self.next_app(environ, partial(self.process, environ, start_response))
+
+    def process(
+        self,
+        environ: Dict[str, Any],
+        start_response: Callable,
+        status: int,
+        headers: List[Tuple[str, str]],
+        exc_info=None,
+    ):
+        res = start_response(status, headers, exc_info)
+        self.cleanup_db_connections()
+        return res
+
+    def cleanup_db_connections(self):
+        # This is a bit ugly, but: Our unit tests run in a transaction, and
+        # therefore we can't *really* close the obsolete connections, as it
+        # would break the tests. Other than that, this is an exact copy of
+        # `django.db.close_old_connections()`.
+        for conn in connections.all(initialized_only=True):
+            if not conn.in_atomic_block:  # pragma: no cover
+                conn.close_if_unusable_or_obsolete()
 
 
 def get_dav():
@@ -32,6 +78,7 @@ def get_dav():
             ),
         },
         "middleware_stack": [
+            ManageDjangoConnectionsMiddleware,
             HeaderLogger,
             WsgiDavDebugFilter,
             ErrorPrinter,

--- a/alexandria/settings/django.py
+++ b/alexandria/settings/django.py
@@ -49,6 +49,7 @@ DATABASES = {
         "HOST": env.str("DATABASE_HOST", default="localhost"),
         "PORT": env.str("DATABASE_PORT", default=""),
         "OPTIONS": env.dict("DATABASE_OPTIONS", default={}),
+        "CONN_HEALTH_CHECKS": True,
     }
 }
 


### PR DESCRIPTION
Django calls a function to close unused/obsolete DB connections before and after each request. In WebDAV, we don't use Django infrastructure to deal with requests, and therefore that cleanup code is not being called.

This introduces a WSGIDav middleware to fix that problem.

However since our unit tests run in transactions, it's a bit uglier (and less tested) than I'd like it to be...