### PR TITLE
feat(export): use renamed filenames in export zip

### DIFF
--- a/alexandria/core/views.py
+++ b/alexandria/core/views.py
@@ -235,12 +235,29 @@ class FileViewSet(
 
                 temp_file.seek(0)
 
-                name = _file.name
+                name = _file.document.title
                 suffixes = itertools.count(start=1)
+                (base_name, *maybe_ext) = name.rsplit(".", 1)
+                (_, *maybe_ext_original) = _file.name.rsplit(".", 1)
+
+                # maybe_ext/maybe_ext_original is now a 0- or 1-sized list
+                extension = f".{maybe_ext[0]}" if maybe_ext else ""
+
+                # fallback to original file extension if lost due to renaming
+                if maybe_ext_original and maybe_ext_original[0] != extension:
+                    extension = f".{maybe_ext_original[0]}"
+
+                    # use the full renamed document title as base name,
+                    # but strip the extension if it is the same as the original
+                    # to avoid double extensions like "document.pdf.pdf"
+                    base_name = (
+                        name
+                        if not name.endswith(extension)
+                        else name[: -len(extension)]
+                    )
+
+                name = f"{base_name}{extension}"
                 while name in seen_names:
-                    (base_name, *maybe_ext) = _file.name.rsplit(".", 1)
-                    # extension is now a 0- or 1-sized list
-                    extension = f".{maybe_ext[0]}" if maybe_ext else ""
                     name = f"{base_name}({next(suffixes)}){extension}"
                 seen_names.add(name)
 


### PR DESCRIPTION
Files can be renamed, and in the zip download the new name should be used.

Since the document title is free to fill, not regarding any extension, I did add some logic to always remain the original extension in the final result.