### PR TITLE
chore(release): v7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.3.0
+
+### Feature
+
+* **export:** Use renamed filenames in export zip ([`4d64d4a`](https://github.com/nlzet/alexandria/commit/4d64d4a45ab51158551c4492934e57cd3fc2a961))
+
 # 7.2.4
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma-alexandria"
-version = "7.2.4"
+version = "7.3.0"
 description = "Document management service"
 repository = "https://github.com/projectcaluma/alexandria"
 authors = ["Caluma <info@caluma.io>"]


### PR DESCRIPTION
# 7.3.0

### Feature

* **export:** Use renamed filenames in export zip ([`4d64d4a`](https://github.com/nlzet/alexandria/commit/4d64d4a45ab51158551c4492934e57cd3fc2a961))