### PR TITLE
fix(deps): fix docker base image based on debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim AS base
+FROM python:3.10-slim-bookworm AS base
 
 ENV DJANGO_SETTINGS_MODULE=alexandria.settings.django \
     PYTHONFAULTHANDLER=1 \


### PR DESCRIPTION
Tests are currently failing on main https://github.com/projectcaluma/alexandria/actions

Snapshots with file checksums are failing, because the base image changed from debian bookworm to trixie, using different system packages. I'd suggest switching back to bookworm for now

**Current main:**

    # cat /etc/os-release
    PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
    NAME="Debian GNU/Linux"
    VERSION_ID="13"
    VERSION="13 (trixie)"
    VERSION_CODENAME=trixie
    DEBIAN_VERSION_FULL=13.0


**After change / current production image:**

    # cat /etc/os-release
    PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
    NAME="Debian GNU/Linux"
    VERSION_ID="12"
    VERSION="12 (bookworm)"
    VERSION_CODENAME=bookworm

