### PR TITLE
fix(download): use renamed filename in single and multi download

### DIFF
--- a/alexandria/core/models.py
+++ b/alexandria/core/models.py
@@ -257,6 +257,27 @@ class File(UUIDModel):
 
         return make_presigned_url(reverse("file-download", args=[self.pk]), request)
 
+    def get_download_filename(self):
+        try:
+            name = self.document.title
+        except AttributeError:
+            name = self.name
+
+        extension = "".join(Path(name).suffixes)
+        base_name = name[: -len(extension)] if extension else name
+        ext_original = "".join(Path(self.name).suffixes)
+
+        # fallback to original extension if lost due to rename
+        if ext_original and ext_original != extension:
+            extension = ext_original
+            # use original filename as base_name and add extension
+            base_name = name
+
+        return (
+            base_name,
+            extension,
+        )
+
     class Meta:
         ordering = ["-created_at"]
         indexes = [GinIndex(fields=["content_vector"])]

--- a/alexandria/core/tests/test_views.py
+++ b/alexandria/core/tests/test_views.py
@@ -342,6 +342,16 @@ def test_multi_download(admin_client, file_factory):
                     "filename": "c_file.jpg",
                     "title": "c_file.png",
                 },
+                {
+                    # double extension
+                    "filename": "d_file.tar.gz",
+                    "title": "d_file.tar.gz",
+                },
+                {
+                    # renamed to same double extension
+                    "filename": "e_file.tar.gz",
+                    "title": "d_file.tar.gz",
+                },
             ],
             [
                 "a_file.jpg",  # original name/title
@@ -349,6 +359,8 @@ def test_multi_download(admin_client, file_factory):
                 "b_file.jpg test.jpg",  # extension recovered on appended title
                 "b_file.jpg test(1).jpg",  # suffix on recovered extension appended title
                 "c_file.png.jpg",  # original extension recovered on top of renamed title
+                "d_file.tar.gz",  # original double extension
+                "d_file(1).tar.gz",  # suffix on original double extension
             ],
         ),
     ],


### PR DESCRIPTION
Changed the download filenames in zips reflecting renamed files in https://github.com/projectcaluma/alexandria/pull/869

This MR applies the same in single file downloads

Changed a little bit to reflect the file extension correctly on file versions.

**Example context:**

- Upload a new file `Example.docx`: Download filename is `Example.docx`
- Rename to `Example.test`, Download filename is `Example.test.docx`
- Rename back to `Example.docx`, download filename is `Example.docx`
- Replace the file with a new upload `Example.jpg`, the document title does not change!  (`Example.docx`)
- Download latest file version: download filename is `Example.docx.jpg`
- Download previous file version: download filename is `Example.docx`
- Rename document title to `Example.jpg`
- Download latest file version: download filename is `Example.jpg`
- Download previous file version: download filename is `Example.jpg.docx`