### PR TITLE
chore(release): v8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.0.1
+
+### Fix
+
+* **download:** Use renamed filename in single and multi download ([`39d9b93`](https://github.com/nlzet/alexandria/commit/39d9b932e4d79fde875f25bb14dd231d9b5d14a5))
+
 # 8.0.0
 
 ### Feature

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma-alexandria"
-version = "8.0.0"
+version = "8.0.1"
 description = "Document management service"
 repository = "https://github.com/projectcaluma/alexandria"
 authors = ["Caluma <info@caluma.io>"]


### PR DESCRIPTION
CHANGELOG:

    ### Fix

    * **download:** Use renamed filename in single and multi download ([`39d9b93`](https://github.com/nlzet/alexandria/commit/39d9b932e4d79fde875f25bb14dd231d9b5d14a5))