### PR TITLE
feat(s3): add setting for CLIENT_CONFIG

### DIFF
--- a/alexandria/settings/alexandria.py
+++ b/alexandria/settings/alexandria.py
@@ -153,6 +153,7 @@ ALEXANDRIA_S3_BUCKET_NAME = env.str(
 )
 # Object parameter translate to specific headers and values in put and get requests
 ALEXANDRIA_S3_OBJECT_PARAMETERS = {}
+ALEXANDRIA_S3_CLIENT_CONFIG = env.dict("ALEXANDRIA_S3_CLIENT_CONFIG", default={})
 # Shared secret for at-rest encryption of objects
 # NOTE: required to be 32 bytes long
 ALEXANDRIA_S3_STORAGE_SSEC_SECRET = env.str(

--- a/alexandria/storages/backends/s3.py
+++ b/alexandria/storages/backends/s3.py
@@ -1,3 +1,4 @@
+from botocore.config import Config as BotoConfig
 from django.conf import ImproperlyConfigured, settings as django_settings
 from storages.backends.s3 import S3Storage as OriginalS3Storage
 from storages.utils import setting
@@ -16,6 +17,7 @@ class S3Storage(OriginalS3Storage):
             "use_ssl": setting("ALEXANDRIA_S3_USE_SSL"),
             "verify": setting("ALEXANDRIA_S3_VERIFY"),
             "object_parameters": setting("ALEXANDRIA_S3_OBJECT_PARAMETERS", {}),
+            "client_config": BotoConfig(**setting("ALEXANDRIA_S3_CLIENT_CONFIG")),
         }
 
 


### PR DESCRIPTION
This config is needed to work around https://github.com/boto/boto3/issues/4435 when using a third-party/non-AWS S3 backend.