### PR TITLE
fix: set different image for celery dev

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,5 @@
 ---
 x-alexandria-common: &alexandria-common
-  image: ghcr.io/projectcaluma/alexandria:dev
   depends_on:
     - db
     - minio
@@ -27,6 +26,7 @@ services:
 
   alexandria:
     <<: *alexandria-common
+    image: ghcr.io/projectcaluma/alexandria:dev
     ports:
       - "8000:8000"
 
@@ -88,6 +88,7 @@ services:
 
   celery:
     <<: *alexandria-common
+    image: ghcr.io/projectcaluma/alexandria-celery:dev
     volumes:
       - ./celery/entrypoint.sh:/entrypoint.sh
     entrypoint: /entrypoint.sh


### PR DESCRIPTION
to avoid naming collision with alexandria dev image (see https://github.com/projectcaluma/alexandria/actions/runs/22062530540/job/63746072477 for example error)