### PR TITLE
chore(compose): adapt psql data dir mount to psql v18+ convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ start: ## Start the development server
 
 .PHONY: test
 test: ## Test the backend
-	@docker compose run --rm alexandria pytest --no-cov-on-fail --cov --create-db -vv
+	@docker compose run --rm alexandria sh -c 'wait-for-it db:5432 -- pytest --no-cov-on-fail --cov --create-db -vv'
 
 .PHONY: lint
 lint: ## Lint the backend

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
       # https://hub.docker.com/_/postgres
       # - POSTGRES_PASSWORD=
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - dbdata18:/var/lib/postgresql
 
   alexandria:
     <<: *alexandria-common
@@ -94,7 +94,7 @@ services:
     entrypoint: /entrypoint.sh
 
 volumes:
-  dbdata:
+  dbdata18:
   redis_data:
   minio_data:
     driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ x-alexandria-common: &alexandria-common
 
 services:
   db:
-    image: postgres:alpine
+    image: postgres:18.4-alpine3.23
     environment:
       - POSTGRES_USER=alexandria
       # following option is a must to configure on production system:


### PR DESCRIPTION
Error after pq update:
```
Important Change: the PGDATA environment variable of the image was changed to be version specific in PostgreSQL 18 and above⁠. For 18 it is /var/lib/postgresql/18/docker. Later versions will replace 18 with their respective major version (e.g., /var/lib/postgresql/19/docker for PostgreSQL 19.x). The defined VOLUME was changed in 18 and above to /var/lib/postgresql. Mounts and volumes should be targeted at the updated location. This will allow users upgrading between PostgreSQL major releases to use the faster --link when running pg_upgrade and mounting /var/lib/postgresql.
```

See https://aronschueler.de/blog/2025/10/30/fixing-postgres-18-docker-compose-startup/

---

TL;DR: psql 18+ changed the env var for the data dir.

 Instead use `/var/lib/postgresql` for volume mount. So docker will create sub dirs for every major pq version like `18/docker/`.