### PR TITLE
chore: release v8.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.9.1
+### Fix
+
+* Fix string formatting for correct translation ([`181ba6a`](https://github.com/projectcaluma/alexandria/commit/181ba6a9a373ce69ba74206887584bc71e7fd515))
+
 # 8.9.0
 ### Feature
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma-alexandria"
-version = "8.9.0"
+version = "8.9.1"
 description = "Document management service"
 repository = "https://github.com/projectcaluma/alexandria"
 authors = ["Caluma <info@caluma.io>"]


### PR DESCRIPTION
### Fix

* Fix string formatting for correct translation ([`181ba6a`](https://github.com/projectcaluma/alexandria/commit/181ba6a9a373ce69ba74206887584bc71e7fd515))