### PR TITLE
feat(celery): add enqueue option for content vector generation command

### DIFF
--- a/alexandria/core/management/commands/generate_content_vectors.py
+++ b/alexandria/core/management/commands/generate_content_vectors.py
@@ -11,6 +11,13 @@ from alexandria.core.tasks import set_content_vector
 class Command(BaseCommand):
     help = "Fills content_vector for files that don't have their content vectorized for full text search."
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--enqueue",
+            action="store_true",
+            help="Enqueue content vector generation as Celery tasks instead of processing files synchronously.",
+        )
+
     def handle(self, *args, **options):
         if not settings.ALEXANDRIA_ENABLE_CONTENT_SEARCH:
             return self.stdout.write(
@@ -34,7 +41,11 @@ class Command(BaseCommand):
                 f"Processing {truncatechars(file.name, 50):<50} ({filesizeformat(file.size):>10})"
             )
             try:
-                set_content_vector(file.pk)
+                if options["enqueue"]:
+                    set_content_vector.apply_async(args=[file.pk])
+                else:
+                    set_content_vector(file.pk)
+
             except Exception as e:  # noqa: B902
                 failed_files.append(str(file.id))
                 self.stdout.write(

--- a/alexandria/core/tests/test_commands.py
+++ b/alexandria/core/tests/test_commands.py
@@ -83,6 +83,21 @@ def test_generate_content_vector(
     assert file_without_vector.language == "de"
 
 
+def test_generate_content_vector_enqueue(db, settings, file_factory, mocker):
+    settings.ALEXANDRIA_ENABLE_CONTENT_SEARCH = False
+    settings.ALEXANDRIA_ENABLE_THUMBNAIL_GENERATION = False
+    files = [file_factory(name="first.pdf"), file_factory(name="second.pdf")]
+    settings.ALEXANDRIA_ENABLE_CONTENT_SEARCH = True
+    enqueue = mocker.patch(
+        "alexandria.core.management.commands.generate_content_vectors.set_content_vector.apply_async"
+    )
+
+    call_command("generate_content_vectors", enqueue=True)
+
+    enqueued_file_ids = [call.kwargs["args"][0] for call in enqueue.call_args_list]
+    assert sorted(enqueued_file_ids) == sorted(file.pk for file in files)
+
+
 def test_generate_missing_checksums(
     db,
     settings,


### PR DESCRIPTION
Adds an optional argument to the `generate_content_vectors` command to insert the tasks as celery jobs instead of executing each task.